### PR TITLE
Fix conversation ordering for MySQL

### DIFF
--- a/application/Api/Conversation.php
+++ b/application/Api/Conversation.php
@@ -29,7 +29,7 @@ class Conversation extends ApiController
                       FROM conversations c
                       JOIN conversation_participants cp ON c.id = cp.conversation_id
                       WHERE cp.user_id = ?
-                      ORDER BY last_message_time DESC NULLS LAST";
+                      ORDER BY last_message_time IS NULL, last_message_time DESC";
 
             $result = ConversationModel::getUserConversationsPaginated($query, [$user['user_id']]);
 

--- a/application/Api/Models/ConversationModel.php
+++ b/application/Api/Models/ConversationModel.php
@@ -58,7 +58,7 @@ class ConversationModel
                 FROM conversations c
                 JOIN conversation_participants cp ON c.id = cp.conversation_id
                 WHERE cp.user_id = ?
-                ORDER BY last_message_time DESC NULLS LAST
+                ORDER BY last_message_time IS NULL, last_message_time DESC
                 LIMIT ? OFFSET ?";
 
         return $db->query($sql, [$userId, $limit, $offset])->fetchAll();

--- a/framework/core/Database.php
+++ b/framework/core/Database.php
@@ -59,7 +59,9 @@ class Database
         $start = ($page == 0 ? 0 : ($page - 1) * $limit);
         $page_num = ($page == 0 ? 1 : $page);
 
-        $sql = "$query OFFSET $start LIMIT $limit";
+        $sql = DB_TYPE === 'mysql'
+            ? "$query LIMIT $limit OFFSET $start"
+            : "$query OFFSET $start LIMIT $limit";
 
         if (empty($values)) {
 


### PR DESCRIPTION
## Summary
- replace Postgres-specific `NULLS LAST` sort with MySQL-compatible expression in conversation listings
- adjust pagination query helper for MySQL `LIMIT ... OFFSET` syntax

## Testing
- `php -l application/Api/Models/ConversationModel.php`
- `php -l application/Api/Conversation.php`
- `php -l framework/core/Database.php`
- `curl -s -H "Authorization: Bearer testtoken" http://127.0.0.1:8000/api/conversation`

------
https://chatgpt.com/codex/tasks/task_b_6896e13cc160832a8d52158a21cfb12f