### PR TITLE
Fix conversation pagination offset

### DIFF
--- a/application/Api/Chat.php
+++ b/application/Api/Chat.php
@@ -18,9 +18,10 @@ class Chat extends ApiController
         $user = $this->authenticate();
         $page = (int)($_GET['page'] ?? 1);
         $perPage = min((int)($_GET['per_page'] ?? 20), 100);
+        $offset = ($page - 1) * $perPage;
 
         try {
-            $conversations = ConversationModel::getUserConversations($user['user_id'], $page, $perPage);
+            $conversations = ConversationModel::getUserConversations($user['user_id'], $perPage, $offset);
 
             $this->respondSuccess($conversations, 'Conversations retrieved successfully');
         } catch (\Exception $e) {


### PR DESCRIPTION
## Summary
- Calculate pagination offset in chat conversations endpoint
- Pass correct limit and offset to ConversationModel::getUserConversations

## Testing
- `php test_chat_conversations.php` *(validated offset handling in a stubbed model)*
- `php -l application/Api/Chat.php`


------
https://chatgpt.com/codex/tasks/task_b_6896e15223b4832aabc29f360b8d5517