### PR TITLE
Ensure device registration uses correct parameter order

### DIFF
--- a/application/Api/Device.php
+++ b/application/Api/Device.php
@@ -24,8 +24,8 @@ class Device extends ApiController
                 $data['device_id'],
                 $data['platform'],
                 $data['fcm_token'] ?? null,
-                $data['app_version'] ?? null,
                 $data['device_name'] ?? null,
+                $data['app_version'] ?? null,
                 $data['os_version'] ?? null
             );
 

--- a/application/Api/User.php
+++ b/application/Api/User.php
@@ -284,8 +284,8 @@ class User extends ApiController
                 $data['device_id'],
                 $data['platform'] ?? 'web',
                 $data['fcm_token'] ?? null,
-                $data['app_version'] ?? null,
                 $data['device_name'] ?? null,
+                $data['app_version'] ?? null,
                 $data['os_version'] ?? null
             );
         }


### PR DESCRIPTION
## Summary
- Fix argument order for `DeviceModel::registerDevice` in Device API register endpoint
- Correct argument order in User login device registration

## Testing
- `php -l application/Api/Device.php`
- `php -l application/Api/User.php`


------
https://chatgpt.com/codex/tasks/task_b_6896e1599f80832a8871365640f91654