### PR TITLE
Store original attachment filename

### DIFF
--- a/API_DOCUMENTATION.md
+++ b/API_DOCUMENTATION.md
@@ -270,6 +270,13 @@ Send a new message.
 }
 ```
 
+Each attachment object may include:
+
+- `file_url` (string): Required file location
+- `file_type` (string): Required MIME type
+- `file_size` (int, optional): Size in bytes
+- `original_name` (string, optional): Original filename
+
 ### GET /api/message/{id}
 
 Get specific message details.
@@ -313,6 +320,18 @@ Upload file for message attachment.
 **Form Data:**
 
 - `file`: File to upload (max 50MB)
+
+**Response:**
+
+```json
+{
+  "attachment_id": 1,
+  "file_url": "/uploads/messages/file.pdf",
+  "file_type": "application/pdf",
+  "file_size": 102400,
+  "original_name": "document.pdf"
+}
+```
 
 ### GET /api/message/search
 

--- a/application/Api/Message.php
+++ b/application/Api/Message.php
@@ -375,7 +375,8 @@ class Message extends ApiController
                     $user['user_id'],
                     $fileUrl,
                     $file['type'],
-                    $file['size']
+                    $file['size'],
+                    $file['name']
                 );
 
                 $this->respondSuccess([

--- a/application/Api/Models/MessageAttachmentModel.php
+++ b/application/Api/Models/MessageAttachmentModel.php
@@ -19,32 +19,32 @@ class MessageAttachmentModel
     /**
      * Add attachment to a message (alias for createAttachment)
      */
-    public static function addAttachment($messageId, $fileUrl, $mimeType, $fileSize = null, $uploaderId = 1)
+    public static function addAttachment($messageId, $fileUrl, $mimeType, $fileSize = null, $originalName = null, $uploaderId = 1)
     {
-        return self::createAttachment($messageId, $uploaderId, $fileUrl, $mimeType, $fileSize);
+        return self::createAttachment($messageId, $uploaderId, $fileUrl, $mimeType, $fileSize, $originalName);
     }
 
-    public static function createAttachment($messageId, $uploaderId, $fileUrl, $mimeType = null, $size = null)
+    public static function createAttachment($messageId, $uploaderId, $fileUrl, $mimeType = null, $size = null, $originalName = null)
     {
         $db = self::initDB();
 
         $result = $db->query(
-            "INSERT INTO message_attachments (message_id, uploader_id, file_url, mime_type, size, uploaded_at, linked) 
-             VALUES (?, ?, ?, ?, ?, NOW(), 1)",
-            [$messageId, $uploaderId, $fileUrl, $mimeType, $size]
+            "INSERT INTO message_attachments (message_id, uploader_id, file_url, mime_type, size, original_name, uploaded_at, linked)
+             VALUES (?, ?, ?, ?, ?, ?, NOW(), 1)",
+            [$messageId, $uploaderId, $fileUrl, $mimeType, $size, $originalName]
         );
 
         return $db->lastInsertId();
     }
 
-    public static function createUnlinkedAttachment($uploaderId, $fileUrl, $mimeType = null, $size = null)
+    public static function createUnlinkedAttachment($uploaderId, $fileUrl, $mimeType = null, $size = null, $originalName = null)
     {
         $db = self::initDB();
 
         $result = $db->query(
-            "INSERT INTO message_attachments (uploader_id, file_url, mime_type, size, uploaded_at, linked) 
-             VALUES (?, ?, ?, ?, NOW(), 0)",
-            [$uploaderId, $fileUrl, $mimeType, $size]
+            "INSERT INTO message_attachments (uploader_id, file_url, mime_type, size, original_name, uploaded_at, linked)
+             VALUES (?, ?, ?, ?, ?, NOW(), 0)",
+            [$uploaderId, $fileUrl, $mimeType, $size, $originalName]
         );
 
         return $db->lastInsertId();
@@ -103,9 +103,10 @@ class MessageAttachmentModel
         $db = self::initDB();
 
         return $db->query(
-            "DELETE FROM message_attachments 
+            "DELETE FROM message_attachments
              WHERE linked = 0 AND uploaded_at < DATE_SUB(NOW(), INTERVAL ? HOUR)",
             [$olderThanHours]
         );
     }
 }
+

--- a/chat.sql
+++ b/chat.sql
@@ -96,6 +96,7 @@ CREATE TABLE `message_attachments` (
   `uploader_id` bigint UNSIGNED NOT NULL,
   `file_url` text COLLATE utf8mb4_general_ci NOT NULL,
   `mime_type` varchar(100) COLLATE utf8mb4_general_ci DEFAULT NULL,
+  `original_name` varchar(255) COLLATE utf8mb4_general_ci DEFAULT NULL,
   `size` bigint UNSIGNED DEFAULT NULL,
   `uploaded_at` datetime DEFAULT CURRENT_TIMESTAMP,
   `linked` tinyint(1) DEFAULT '0'


### PR DESCRIPTION
## Summary
- persist attachment original_name in DB and model
- record original file name during upload and message creation
- document original_name field in API and schema

## Testing
- `php -l application/Api/Models/MessageAttachmentModel.php`
- `php -l application/Api/Message.php`


------
https://chatgpt.com/codex/tasks/task_b_6896e180e734832aaa586e126734126e