### PR TITLE
Check conversation membership before returning messages

### DIFF
--- a/application/Api/Chat.php
+++ b/application/Api/Chat.php
@@ -76,6 +76,11 @@ class Chat extends ApiController
             $this->respondError(400, 'Conversation ID is required');
         }
 
+        if (!ConversationParticipantModel::isParticipant($conversationId, $user['user_id'])) {
+            $this->respondError(403, 'User is not a participant of this conversation');
+            return;
+        }
+
         try {
             $messages = MessageModel::getConversationMessagesWithDetails($conversationId, $limit, $offset);
 

--- a/tests/ChatMessagesUnauthorizedTest.php
+++ b/tests/ChatMessagesUnauthorizedTest.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace App\Api\Models {
+    class ConversationParticipantModel {
+        public static $called = false;
+        public static function isParticipant($conversationId, $userId) {
+            self::$called = true;
+            return false;
+        }
+    }
+    class MessageModel {
+        public static function getConversationMessagesWithDetails($conversationId, $limit, $offset) {
+            throw new \RuntimeException('should not be called');
+        }
+    }
+}
+
+namespace App\Api {
+    abstract class ApiController {}
+}
+
+namespace Tests {
+
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/../application/Api/Chat.php';
+
+class ChatMessagesUnauthorizedTest extends TestCase
+{
+    public function testMessagesReturns403WhenUserNotParticipant(): void
+    {
+        $chat = new class extends \App\Api\Chat {
+            public $statusCode;
+            public function __construct() {}
+            protected function authenticate($required = true)
+            {
+                return ['user_id' => 99];
+            }
+            protected function respondError($statusCode, $message, $errors = null)
+            {
+                $this->statusCode = $statusCode;
+                throw new \Exception('error');
+            }
+            protected function respondSuccess($data = null, $message = 'Success', $statusCode = 200)
+            {
+                $this->statusCode = $statusCode;
+                throw new \Exception('success');
+            }
+        };
+
+        $_GET['conversation_id'] = 1;
+
+        try {
+            $chat->messages();
+        } catch (\Exception $e) {
+            // Ignore to allow assertions
+        }
+
+        $this->assertEquals(403, $chat->statusCode);
+        $this->assertTrue(\App\Api\Models\ConversationParticipantModel::$called);
+    }
+}
+}


### PR DESCRIPTION
## Summary
- Ensure `/api/chat/messages` verifies that the user is a participant before returning messages and respond with 403 otherwise.
- Add unit test covering unauthorized access to conversation messages.

## Testing
- `phpunit tests/ChatMessagesUnauthorizedTest.php`


------
https://chatgpt.com/codex/tasks/task_b_6896e18a2824832a90edb8c639fbc843