### PR TITLE
Introduce base Model and adopt DBManager for database access

### DIFF
--- a/application/Api/Models/ConversationParticipantModel.php
+++ b/application/Api/Models/ConversationParticipantModel.php
@@ -2,123 +2,105 @@
 
 namespace App\Api\Models;
 
-use Framework\Core\Database;
+use Framework\Core\Model;
 
-class ConversationParticipantModel
+class ConversationParticipantModel extends Model
 {
-    private static $db;
-
-    public static function initDB()
-    {
-        if (!self::$db) {
-            self::$db = new Database();
-        }
-        return self::$db;
-    }
+    protected static string $table = 'conversation_participants';
+    protected array $fillable = ['conversation_id', 'user_id', 'role', 'joined_at', 'last_read_message_id'];
+    protected bool $timestamps = false;
 
     public static function isParticipant($conversationId, $userId)
     {
-        $db = self::initDB();
-
-        $result = $db->query(
-            "SELECT COUNT(*) as count FROM conversation_participants WHERE conversation_id = ? AND user_id = ?",
-            [$conversationId, $userId]
-        )->fetchArray();
-
-        return $result['count'] > 0;
+        return static::first([
+            'conversation_id' => $conversationId,
+            'user_id'        => $userId,
+        ]) !== null;
     }
 
     public static function addParticipant($conversationId, $userId, $isAdmin = false)
     {
-        $db = self::initDB();
-
-        // Check if participant already exists
-        $existing = $db->query(
-            "SELECT id FROM conversation_participants WHERE conversation_id = ? AND user_id = ?",
-            [$conversationId, $userId]
-        )->fetchArray();
-
-        if ($existing) {
-            return false; // Already exists
+        if (static::isParticipant($conversationId, $userId)) {
+            return false;
         }
 
-        $role = $isAdmin ? 'admin' : 'member';
-
-        return $db->query(
-            "INSERT INTO conversation_participants (conversation_id, user_id, role, joined_at) VALUES (?, ?, ?, NOW())",
-            [$conversationId, $userId, $role]
-        );
+        $participant = new static([
+            'conversation_id' => $conversationId,
+            'user_id'         => $userId,
+            'role'            => $isAdmin ? 'admin' : 'member',
+        ]);
+        $participant->save();
+        return true;
     }
 
     public static function addMultipleParticipants($conversationId, $userIds, $isAdmin = false)
     {
-        $db = self::initDB();
         $addedCount = 0;
-
         foreach ($userIds as $userId) {
             if (self::addParticipant($conversationId, $userId, $isAdmin)) {
                 $addedCount++;
             }
         }
-
         return $addedCount;
     }
 
     public static function removeParticipant($conversationId, $userId)
     {
-        $db = self::initDB();
-
-        return $db->query(
-            "DELETE FROM conversation_participants WHERE conversation_id = ? AND user_id = ?",
-            [$conversationId, $userId]
-        );
+        $participant = static::first([
+            'conversation_id' => $conversationId,
+            'user_id'        => $userId,
+        ]);
+        if (!$participant) {
+            return false;
+        }
+        $participant->delete();
+        return true;
     }
 
     public static function updateLastReadMessage($conversationId, $userId, $messageId)
     {
-        $db = self::initDB();
-
-        return $db->query(
-            "UPDATE conversation_participants SET last_read_message_id = ? WHERE conversation_id = ? AND user_id = ?",
-            [$messageId, $conversationId, $userId]
-        );
+        $participant = static::first([
+            'conversation_id' => $conversationId,
+            'user_id'        => $userId,
+        ]);
+        if (!$participant) {
+            return false;
+        }
+        $participant->last_read_message_id = $messageId;
+        $participant->save();
+        return true;
     }
 
     public static function isAdmin($conversationId, $userId)
     {
-        $db = self::initDB();
-
-        $result = $db->query(
-            "SELECT role FROM conversation_participants WHERE conversation_id = ? AND user_id = ?",
-            [$conversationId, $userId]
-        )->fetchArray();
-
-        return $result && $result['role'] === 'admin';
+        $participant = static::first([
+            'conversation_id' => $conversationId,
+            'user_id'        => $userId,
+        ]);
+        return $participant && $participant->role === 'admin';
     }
 
     public static function getParticipants($conversationId)
     {
-        $db = self::initDB();
+        $db = static::db();
 
         return $db->query(
-            "SELECT cp.*, u.name, u.username, u.email, u.avatar_url
-             FROM conversation_participants cp
-             JOIN users u ON cp.user_id = u.id
-             WHERE cp.conversation_id = ?
-             ORDER BY cp.joined_at ASC",
+            "SELECT cp.*, u.name, u.username, u.email, u.avatar_url"
+            . " FROM conversation_participants cp"
+            . " JOIN users u ON cp.user_id = u.id"
+            . " WHERE cp.conversation_id = ?"
+            . " ORDER BY cp.joined_at ASC",
             [$conversationId]
         )->fetchAll();
     }
 
     public static function getParticipantRole($conversationId, $userId)
     {
-        $db = self::initDB();
-
-        $result = $db->query(
-            "SELECT role FROM conversation_participants WHERE conversation_id = ? AND user_id = ?",
-            [$conversationId, $userId]
-        )->fetchArray();
-
-        return $result ? $result['role'] : null;
+        $participant = static::first([
+            'conversation_id' => $conversationId,
+            'user_id'        => $userId,
+        ]);
+        return $participant ? $participant->role : null;
     }
 }
+

--- a/framework/core/Controller.php
+++ b/framework/core/Controller.php
@@ -12,8 +12,7 @@ class Controller
     {
 
         if (!$this->db) {
-
-            $this->db = new Database;
+            $this->db = DBManager::getDB();
         }
 
         $response = $log_response = json_encode($this->data);

--- a/framework/core/Model.php
+++ b/framework/core/Model.php
@@ -1,0 +1,353 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Framework\Core;
+
+use InvalidArgumentException;
+use RuntimeException;
+
+abstract class Model
+{
+    protected static string $table;
+    protected static string $primaryKey = 'id';
+
+    // Whitelist of mass-assignable columns
+    protected array $fillable = [];
+
+    // Auto-manage created_at / updated_at if present
+    protected bool $timestamps = true;
+
+    // Current and original state for dirty checking
+    protected array $attributes = [];
+    protected array $original = [];
+
+    public function __construct(array $attributes = [])
+    {
+        $this->fill($attributes);
+        $this->original = $this->attributes;
+    }
+
+    protected static function db(): Database
+    {
+        return DBManager::getDB();
+    }
+
+    public function __get(string $name): mixed
+    {
+        return $this->attributes[$name] ?? null;
+    }
+
+    public function __set(string $name, mixed $value): void
+    {
+        if (\in_array($name, $this->fillable, true) || $name === static::$primaryKey) {
+            $this->attributes[$name] = $value;
+        }
+    }
+
+    public function fill(array $attributes): void
+    {
+        foreach ($attributes as $key => $value) {
+            if (\in_array($key, $this->fillable, true)) {
+                $this->attributes[$key] = $value;
+            }
+        }
+    }
+
+    public function toArray(): array
+    {
+        return $this->attributes;
+    }
+
+    public static function all(): array
+    {
+        $db = static::db();
+        $table = static::$table;
+
+        $rows = $db->query("SELECT * FROM {$table}")->fetchAll() ?: [];
+
+        return array_map(function (array $row) {
+            $model = new static();
+            // Hydrate all columns, not only fillable
+            $model->attributes = $row;
+            $model->original = $row;
+
+            return $model;
+        }, $rows);
+    }
+
+    public static function find(int $id): ?static
+    {
+        $db = static::db();
+        $table = static::$table;
+        $pk = static::$primaryKey;
+
+        $row = $db->query("SELECT * FROM {$table} WHERE {$pk} = ? LIMIT 1", [$id])->fetchArray();
+        if (!$row) {
+            return null;
+        }
+
+        $model = new static();
+        // Hydrate all columns, not only fillable
+        $model->attributes = $row;
+        $model->original = $row;
+
+        return $model;
+    }
+
+    public function save(): void
+    {
+        $pk = static::$primaryKey;
+        $isNew = empty($this->attributes[$pk]);
+
+        if ($this->timestamps) {
+            $now = $this->now();
+            $this->attributes['updated_at'] = $now;
+
+            if ($isNew) {
+                $this->attributes['created_at'] = $now;
+            }
+        }
+
+        $isNew ? $this->insert() : $this->updateRow();
+
+        // Sync original after successful persistence
+        $this->original = $this->attributes;
+    }
+
+    public function delete(): void
+    {
+        $pk = static::$primaryKey;
+        if (empty($this->attributes[$pk])) {
+            return;
+        }
+
+        $db = static::db();
+        $table = static::$table;
+
+        $db->query("DELETE FROM {$table} WHERE {$pk} = ?", [$this->attributes[$pk]]);
+    }
+
+    protected function insert(): void
+    {
+        $db = static::db();
+        $table = static::$table;
+        $pk = static::$primaryKey;
+
+        // Insert only fillable columns (and any explicitly set primary key)
+        $insertable = array_values(array_unique(array_merge($this->fillable, [$pk])));
+        $data = array_intersect_key($this->attributes, array_flip($insertable));
+        unset($data[$pk]); // let DB autogenerate if auto-increment
+
+        if ($data === []) {
+            throw new RuntimeException('No attributes to insert.');
+        }
+
+        $columns = array_keys($data);
+        $placeholders = array_fill(0, count($columns), '?');
+
+        $sql = sprintf(
+            'INSERT INTO %s (%s) VALUES (%s)',
+            $table,
+            implode(', ', $columns),
+            implode(', ', $placeholders)
+        );
+
+        $db->query($sql, array_values($data));
+
+        // If PK is auto-increment, capture it
+        if (empty($this->attributes[$pk])) {
+            $this->attributes[$pk] = (int) $db->lastInsertID();
+        }
+    }
+
+    protected function updateRow(): void
+    {
+        $db = static::db();
+        $table = static::$table;
+        $pk = static::$primaryKey;
+
+        $changes = $this->changedAttributes();
+
+        // Only persist fillable changes (never overwrite PK here)
+        $changes = array_intersect_key($changes, array_flip($this->fillable));
+
+        if ($changes === []) {
+            return; // nothing to do
+        }
+
+        $sets = [];
+        $values = [];
+        foreach ($changes as $col => $val) {
+            $sets[] = "{$col} = ?";
+            $values[] = $val;
+        }
+        $values[] = $this->attributes[$pk];
+
+        $sql = sprintf(
+            'UPDATE %s SET %s WHERE %s = ?',
+            $table,
+            implode(', ', $sets),
+            $pk
+        );
+
+        $db->query($sql, $values);
+    }
+
+    protected function changedAttributes(): array
+    {
+        $changes = [];
+        foreach ($this->attributes as $key => $value) {
+            $orig = $this->original[$key] ?? null;
+            if ($value !== $orig) {
+                $changes[$key] = $value;
+            }
+        }
+        return $changes;
+    }
+
+    protected function now(): string
+    {
+        $tzName = defined('TIMEZONE') ? TIMEZONE : \date_default_timezone_get();
+        if (!$tzName) {
+            $tzName = 'UTC';
+        }
+
+        try {
+            $tz = new \DateTimeZone($tzName);
+        } catch (\Exception $e) {
+            $tz = new \DateTimeZone('UTC');
+        }
+
+        return (new \DateTimeImmutable('now', $tz))->format('Y-m-d H:i:s');
+    }
+
+    /**
+     * Fetch all rows matching the given conditions.
+     *
+     * Examples:
+     *  User::where(['status' => 'active']);
+     *  User::where([['age', '>=', 18], ['name', 'LIKE', 'A%']]);
+     *  User::where([['id', 'IN', [1,2,3]]]);
+     */
+    public static function where(array $conditions): array
+    {
+        $db = static::db();
+        $table = static::$table;
+
+        [$whereSql, $params] = static::compileWhere($conditions);
+
+        $sql = "SELECT * FROM {$table} {$whereSql}";
+        $rows = $db->query($sql, $params)->fetchAll() ?: [];
+
+        return array_map(function (array $row) {
+            $model = new static();
+            $model->attributes = $row; // hydrate all columns
+            $model->original = $row;
+            return $model;
+        }, $rows);
+    }
+
+    /**
+     * Fetch the first row matching the given conditions or null.
+     *
+     * Examples:
+     *  User::first(['email' => 'foo@example.com']);
+     *  User::first([['created_at', '>=', '2025-01-01 00:00:00']]);
+     */
+    public static function first(array $conditions): ?static
+    {
+        $db = static::db();
+        $table = static::$table;
+
+        [$whereSql, $params] = static::compileWhere($conditions);
+
+        // LIMIT 1 is safe on MySQL/SQLite/Postgres
+        $sql = "SELECT * FROM {$table} {$whereSql} LIMIT 1";
+        $row = $db->query($sql, $params)->fetchArray();
+        if (!$row) {
+            return null;
+        }
+
+        $model = new static();
+        $model->attributes = $row; // hydrate all columns
+        $model->original = $row;
+        return $model;
+    }
+
+    /**
+     * Build a WHERE clause and parameters from a simple conditions array.
+     *
+     * Supported forms:
+     *  - ['col' => $value]
+     *  - ['col', 'OP', $value] where OP ∈ (=, !=, <, >, <=, >=, LIKE, IN)
+     * For IN, value must be an array.
+     *
+     * @return array{0:string,1:array} [whereSql, params]
+     */
+    protected static function compileWhere(array $conditions): array
+    {
+        if ($conditions === []) {
+            return ['', []];
+        }
+
+        $parts = [];
+        $params = [];
+        $paramCounter = 0;
+
+        // Normalize associative ['col' => val] into triplets
+        $normalized = [];
+        foreach ($conditions as $key => $cond) {
+            if (is_string($key)) {
+                $normalized[] = [$key, '=', $cond];
+            } else {
+                // Expect [col, op, val]
+                if (!is_array($cond) || count($cond) !== 3) {
+                    throw new InvalidArgumentException(
+                        'Each condition must be ["col", "op", value] or ["col" => value].'
+                    );
+                }
+                $normalized[] = $cond;
+            }
+        }
+
+        foreach ($normalized as [$col, $op, $val]) {
+            $op = strtoupper(trim((string) $op));
+            switch ($op) {
+                case '=':
+                case '!=':
+                case '<':
+                case '>':
+                case '<=':
+                case '>=':
+                case 'LIKE': {
+                    $paramName = ':p' . $paramCounter++;
+                    $parts[] = "{$col} {$op} {$paramName}";
+                    $params[ltrim($paramName, ':')] = $val;
+                    break;
+                }
+                case 'IN': {
+                    if (!is_array($val) || $val === []) {
+                        // Empty IN lists are always false; return no rows safely
+                        $parts[] = '1=0';
+                        break;
+                    }
+                    $phs = [];
+                    foreach ($val as $v) {
+                        $paramName = ':p' . $paramCounter++;
+                        $phs[] = $paramName;
+                        $params[ltrim($paramName, ':')] = $v;
+                    }
+                    $inList = implode(', ', $phs);
+                    $parts[] = "{$col} IN ({$inList})";
+                    break;
+                }
+                default:
+                    throw new InvalidArgumentException("Unsupported operator: {$op}");
+            }
+        }
+
+        $whereSql = 'WHERE ' . implode(' AND ', $parts);
+        return [$whereSql, $params];
+    }
+}


### PR DESCRIPTION
## Summary
- refactor model classes to declare table metadata and use ActiveRecord helpers like `first()` and `save()`
- add `toArray()` helper to the base `Model` for convenient array conversion
- replace manual SQL in high-level operations (e.g., device registration, conversation checks) with model methods
- respect configured timezone in `Model::now()` by using defined `TIMEZONE` or PHP default before falling back to UTC

## Testing
- `phpunit` *(fails: command not found)*
- `./vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_b_689abce8dcb4832a82667c4a54b7fe48