### PR TITLE
Add basic relations to base model

### DIFF
--- a/application/Api/Models/MessageAttachmentModel.php
+++ b/application/Api/Models/MessageAttachmentModel.php
@@ -64,12 +64,12 @@ class MessageAttachmentModel extends Model
 
     public static function getMessageAttachments($messageId)
     {
-        $db = static::db();
-
-        return $db->query(
-            "SELECT * FROM message_attachments WHERE message_id = ? ORDER BY uploaded_at ASC",
-            [$messageId]
-        )->fetchAll();
+        $message = MessageModel::find((int) $messageId);
+        if (!$message) {
+            return [];
+        }
+        $attachments = $message->attachments;
+        return array_map(fn($a) => $a->toArray(), $attachments);
     }
 
     public static function getAttachmentById($attachmentId)


### PR DESCRIPTION
## Summary
- support hasOne/hasMany/belongsTo relationships in the base Model class
- load sender and attachments via ORM relations in message models to avoid raw SQL
- automatically include loaded relations when serializing models so relation names appear directly in the data
- drop related *_id columns from serialized output once the relation is attached

## Testing
- `php -l framework/core/Model.php`
- `php -l application/Api/Models/MessageModel.php`
- `php -l application/Api/Models/MessageAttachmentModel.php`
- `/root/.local/share/mise/installs/php/8.4.11/.composer/vendor/bin/phpunit tests/ChatMessagesUnauthorizedTest.php`


------
https://chatgpt.com/codex/tasks/task_b_689ad86c4fcc832abf27e803ea176d8b