### PR TITLE
Add firstOrCreate helper to base Model

### DIFF
--- a/framework/core/Model.php
+++ b/framework/core/Model.php
@@ -352,6 +352,22 @@ abstract class Model
     }
 
     /**
+     * Find the first record matching the conditions or create it.
+     */
+    public static function firstOrCreate(array $where, array $attributes = []): static
+    {
+        $existing = static::first($where);
+        if ($existing !== null) {
+            return $existing;
+        }
+
+        $model = new static($attributes + $where);
+        $model->save();
+
+        return $model;
+    }
+
+    /**
      * Build a WHERE clause and parameters from a simple conditions array.
      *
      * Supported forms:


### PR DESCRIPTION
## Summary
- add `Model::firstOrCreate` to either fetch the first matching record or create one

## Testing
- `phpunit tests`


------
https://chatgpt.com/codex/tasks/task_b_689d221de20c832ab9effec0001436cd