### PR TITLE
Add conversation-scoped message search

### DIFF
--- a/application/Api/Chat.php
+++ b/application/Api/Chat.php
@@ -198,7 +198,7 @@ class Chat extends ApiController
         try {
             if ($conversationId) {
                 // Search within specific conversation - use Message model method
-                $messages = MessageModel::searchUserMessages($user['user_id'], $query, $limit, $offset);
+                $messages = MessageModel::searchConversationMessages($user['user_id'], $conversationId, $query, $limit, $offset);
             } else {
                 // Search across all user's conversations
                 $messages = MessageModel::searchUserMessages($user['user_id'], $query, $limit, $offset);

--- a/application/Api/Models/MessageModel.php
+++ b/application/Api/Models/MessageModel.php
@@ -110,6 +110,26 @@ class MessageModel extends Model
     }
 
     /**
+     * Search user's messages within a specific conversation
+     */
+    public static function searchConversationMessages($userId, $conversationId, $searchQuery, $limit, $offset)
+    {
+        $db = static::db();
+
+        return $db->query(
+            "SELECT m.*, u.name as sender_name, u.avatar_url as sender_avatar, c.title as conversation_title"
+            . " FROM messages m"
+            . " JOIN users u ON m.sender_id = u.id"
+            . " JOIN conversations c ON m.conversation_id = c.id"
+            . " JOIN conversation_participants cp ON c.id = cp.conversation_id"
+            . " WHERE cp.user_id = ? AND m.conversation_id = ? AND m.content LIKE ?"
+            . " ORDER BY m.created_at DESC"
+            . " LIMIT ? OFFSET ?",
+            [$userId, $conversationId, "%{$searchQuery}%", $limit, $offset]
+        )->fetchAll();
+    }
+
+    /**
      * Get count of search results for user
      */
     public static function getUserSearchCount($userId, $searchQuery)

--- a/tests/ChatSearchMessagesTest.php
+++ b/tests/ChatSearchMessagesTest.php
@@ -1,0 +1,95 @@
+<?php
+
+namespace App\Api\Models {
+    class MessageModel {
+        public static $lastCalled = null;
+
+        public static function searchUserMessages($userId, $searchQuery, $limit, $offset) {
+            self::$lastCalled = ['method' => __FUNCTION__, 'args' => func_get_args()];
+            return [];
+        }
+
+        public static function searchConversationMessages($userId, $conversationId, $searchQuery, $limit, $offset) {
+            self::$lastCalled = ['method' => __FUNCTION__, 'args' => func_get_args()];
+            return [];
+        }
+    }
+}
+
+namespace App\Api {
+    abstract class ApiController {}
+}
+
+namespace Tests {
+
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/../application/Api/Chat.php';
+
+class ChatSearchMessagesTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        \App\Api\Models\MessageModel::$lastCalled = null;
+        $_GET = [];
+    }
+
+    public function testSearchMessagesWithConversationIdCallsConversationMethod(): void
+    {
+        $_GET['q'] = 'hello';
+        $_GET['conversation_id'] = 5;
+
+        $chat = new class extends \App\Api\Chat {
+            public $statusCode;
+            public function __construct() {}
+            protected function authenticate($required = true)
+            {
+                return ['user_id' => 99];
+            }
+            protected function respondError($statusCode, $message, $errors = null)
+            {
+                $this->statusCode = $statusCode;
+                throw new \Exception('error');
+            }
+            protected function respondSuccess($data = null, $message = 'Success', $statusCode = 200)
+            {
+                $this->statusCode = $statusCode;
+                return $data;
+            }
+        };
+        $chat->searchMessages();
+
+        $this->assertEquals('searchConversationMessages', \App\Api\Models\MessageModel::$lastCalled['method']);
+        $this->assertEquals(200, $chat->statusCode);
+    }
+
+    public function testSearchMessagesWithoutConversationIdCallsUserMethod(): void
+    {
+        $_GET['q'] = 'hello';
+
+        $chat = new class extends \App\Api\Chat {
+            public $statusCode;
+            public function __construct() {}
+            protected function authenticate($required = true)
+            {
+                return ['user_id' => 99];
+            }
+            protected function respondError($statusCode, $message, $errors = null)
+            {
+                $this->statusCode = $statusCode;
+                throw new \Exception('error');
+            }
+            protected function respondSuccess($data = null, $message = 'Success', $statusCode = 200)
+            {
+                $this->statusCode = $statusCode;
+                return $data;
+            }
+        };
+        $chat->searchMessages();
+
+        $this->assertEquals('searchUserMessages', \App\Api\Models\MessageModel::$lastCalled['method']);
+        $this->assertEquals(200, $chat->statusCode);
+    }
+}
+}
+


### PR DESCRIPTION
## Summary
- Allow limiting message searches to a single conversation via `searchConversationMessages`
- Use conversation scoped search when `conversation_id` is supplied in `searchMessages`
- Cover search with and without `conversation_id` in tests

## Testing
- `phpunit tests/ChatSearchMessagesTest.php`
- `phpunit tests/ChatMessagesUnauthorizedTest.php`
- `phpunit tests/ChatSendMessageUnauthorizedTest.php`


------
https://chatgpt.com/codex/tasks/task_b_689d2a3ad264832a8655ae09f697acc7