### PR TITLE
feat: optimize unread count query

### DIFF
--- a/application/Api/Chat.php
+++ b/application/Api/Chat.php
@@ -218,13 +218,7 @@ class Chat extends ApiController
         $user = $this->authenticate();
 
         try {
-            // Get total unread count across all conversations
-            $totalUnread = 0;
-            $conversations = ConversationModel::getUserConversations($user['user_id'], 100, 0);
-
-            foreach ($conversations as $conversation) {
-                $totalUnread += ConversationModel::getUnreadCount($conversation['id'], $user['user_id']);
-            }
+            $totalUnread = ConversationModel::getTotalUnreadCount($user['user_id']);
 
             $this->respondSuccess([
                 'unread_count' => $totalUnread

--- a/application/Api/Models/ConversationModel.php
+++ b/application/Api/Models/ConversationModel.php
@@ -197,4 +197,23 @@ class ConversationModel extends Model
 
         return $result['count'];
     }
+
+    /**
+     * Get total unread message count across all conversations for user
+     */
+    public static function getTotalUnreadCount($userId)
+    {
+        $db = static::db();
+
+        $sql = "SELECT COUNT(*) as count
+                FROM messages m
+                JOIN conversation_participants cp ON m.conversation_id = cp.conversation_id
+                WHERE cp.user_id = ?
+                AND (cp.last_read_message_id IS NULL OR m.id > cp.last_read_message_id)
+                AND m.sender_id != ?";
+
+        $result = $db->query($sql, [$userId, $userId])->fetchArray();
+
+        return $result['count'];
+    }
 }

--- a/tests/ChatUnreadCountTest.php
+++ b/tests/ChatUnreadCountTest.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace App\Api\Models {
+    class ConversationModel {
+        public static bool $totalCalled = false;
+        public static bool $getUserCalled = false;
+        public static bool $getUnreadCalled = false;
+
+        public static function getTotalUnreadCount($userId) {
+            self::$totalCalled = true;
+            // Simulate more than 100 conversations with a total of 150 unread messages
+            return 150;
+        }
+
+        public static function getUserConversations($userId, $limit, $offset) {
+            self::$getUserCalled = true;
+            return [];
+        }
+
+        public static function getUnreadCount($conversationId, $userId) {
+            self::$getUnreadCalled = true;
+            return 0;
+        }
+    }
+}
+
+namespace App\Api {
+    abstract class ApiController {}
+}
+
+namespace Tests {
+
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/../application/Api/Chat.php';
+
+class ChatUnreadCountTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        \App\Api\Models\ConversationModel::$totalCalled = false;
+        \App\Api\Models\ConversationModel::$getUserCalled = false;
+        \App\Api\Models\ConversationModel::$getUnreadCalled = false;
+    }
+
+    public function testUnreadCountUsesAggregateMethod(): void
+    {
+        $chat = new class extends \App\Api\Chat {
+            public $statusCode;
+            public $data;
+            public function __construct() {}
+            protected function authenticate($required = true)
+            {
+                return ['user_id' => 99];
+            }
+            protected function respondError($statusCode, $message, $errors = null)
+            {
+                $this->statusCode = $statusCode;
+                throw new \Exception('error');
+            }
+            protected function respondSuccess($data = null, $message = 'Success', $statusCode = 200)
+            {
+                $this->statusCode = $statusCode;
+                $this->data = $data;
+                return $data;
+            }
+        };
+
+        $chat->unreadCount();
+
+        $this->assertTrue(\App\Api\Models\ConversationModel::$totalCalled);
+        $this->assertFalse(\App\Api\Models\ConversationModel::$getUserCalled);
+        $this->assertFalse(\App\Api\Models\ConversationModel::$getUnreadCalled);
+        $this->assertEquals(200, $chat->statusCode);
+        $this->assertEquals(150, $chat->data['unread_count']);
+    }
+}
+}


### PR DESCRIPTION
## Summary
- add ConversationModel::getTotalUnreadCount to compute unread messages in one query
- use aggregate unread method in Chat controller
- add test covering unread count retrieval via single query

## Testing
- `phpunit tests/ChatMessagesUnauthorizedTest.php`
- `phpunit tests/ChatSearchMessagesTest.php`
- `phpunit tests/ChatSendMessageUnauthorizedTest.php`
- `phpunit tests/ChatUnreadCountTest.php`


------
https://chatgpt.com/codex/tasks/task_b_689d2c0aa89c832a8fba1e2e7c2e3a2c