### PR TITLE
Validate CORS origin against config list

### DIFF
--- a/application/Api/ApiController.php
+++ b/application/Api/ApiController.php
@@ -19,8 +19,21 @@ abstract class ApiController extends Controller
         header('Content-Type: application/json');
 
         // Handle CORS
+        $allowedOrigins = is_array(ALLOWED_ORIGINS)
+            ? ALLOWED_ORIGINS
+            : array_map('trim', explode(',', ALLOWED_ORIGINS));
+
+        $origin = $_SERVER['HTTP_ORIGIN'] ?? null;
+        if ($origin) {
+            if (in_array($origin, $allowedOrigins, true)) {
+                header('Access-Control-Allow-Origin: ' . $origin);
+            } else {
+                http_response_code(403);
+                exit;
+            }
+        }
+
         if ($_SERVER['REQUEST_METHOD'] === 'OPTIONS') {
-            header('Access-Control-Allow-Origin: *');
             header('Access-Control-Allow-Methods: GET, POST, PUT, DELETE, OPTIONS');
             header('Access-Control-Allow-Headers: Content-Type, Authorization');
             http_response_code(200);


### PR DESCRIPTION
## Summary
- Read ALLOWED_ORIGINS from config in ApiController
- Return 403 when HTTP_ORIGIN not permitted
- Set CORS headers only for approved origins

## Testing
- `./phpunit tests/ChatMessagesUnauthorizedTest.php`
- `./phpunit tests/ChatSearchMessagesTest.php`
- `./phpunit tests/ChatSendMessageUnauthorizedTest.php`
- `./phpunit tests/ChatUnreadCountTest.php`


------
https://chatgpt.com/codex/tasks/task_b_68a0bf32ae7c832a8d61c81f1b6d20eb