### PR TITLE
Add example environment config and update installation guide

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,56 @@
+# Example Environment Configuration
+# Copy this file to `.env.local` and adjust settings for your environment.
+
+# Application Settings
+# Base URL of the application
+APP_URL=http://chat.mdriaz.local
+# Force HTTPS redirects (true/false)
+FORCE_HTTPS=false
+# Site title shown in the interface
+SITE_TITLE=Team Chat
+# Application mode (Debug or Live)
+APP_MODE=Debug
+# Default timezone for the application
+TIMEZONE=Asia/Dhaka
+
+# Security & CORS
+# Allowed origins for cross-origin requests (JSON array)
+ALLOWED_ORIGINS=["http://chat.mdriaz.local", "http://localhost", "http://127.0.0.1"]
+# Allow password reset feature
+ALLOW_FORGET_PASSWORD=true
+# Allow new user registration
+ALLOW_REGISTRATION=true
+# Token expiration interval (relative time)
+TOKEN_EXPIRATION=-60 minutes
+# Items per page for paginated responses
+PAGINATION_LIMIT=20
+
+# Database Configuration
+# Database server host
+DB_HOST=localhost
+# Database type (mysql or pgsql)
+DB_TYPE=mysql
+# Database username
+DB_USER=root
+# Database password
+DB_PASS=
+# Database name
+DB_NAME=chat
+# Database port
+DB_PORT=3306
+
+# Redis Configuration
+# Redis server host
+REDIS_HOST=127.0.0.1
+# Redis server port
+REDIS_PORT=6379
+# Redis password (leave empty if not used)
+REDIS_PASSWORD=
+# Redis database index
+REDIS_DATABASE=0
+
+# WebSocket Configuration
+# Host where the WebSocket server listens
+WEBSOCKET_HOST=localhost
+# WebSocket server port
+WEBSOCKET_PORT=8080

--- a/README.md
+++ b/README.md
@@ -72,7 +72,10 @@ The system uses the following core tables:
 
 3. **Configure the application**
 
-   - Copy `.env.local` and update values to match your environment (database, Redis, WebSocket, etc.)
+   - Copy `.env.example` to `.env.local` and update values to match your environment (database, Redis, WebSocket, etc.)
+     ```bash
+     cp .env.example .env.local
+     ```
    - Alternatively update settings directly in `configuration/config.php`
    - Set up your domain and security settings
 


### PR DESCRIPTION
## Summary
- add `.env.example` with documented defaults for application, database, Redis, and WebSocket settings
- update installation instructions to copy the example env file to `.env.local`

## Testing
- `/root/.local/share/mise/installs/php/8.4.11/.composer/vendor/bin/phpunit tests` *(fails: Cannot redeclare class App\Api\Models\MessageModel)*

------
https://chatgpt.com/codex/tasks/task_b_68a0bf5045d4832ab4ad400acc4b7081