### PR TITLE
Validate JSON input in API controller

### DIFF
--- a/application/Api/ApiController.php
+++ b/application/Api/ApiController.php
@@ -67,7 +67,13 @@ abstract class ApiController extends Controller
     protected function getJsonInput()
     {
         $json = file_get_contents('php://input');
-        return json_decode($json, true) ?? [];
+        $data = json_decode($json, true);
+
+        if (json_last_error() !== JSON_ERROR_NONE) {
+            $this->respondError(400, 'Invalid JSON body');
+        }
+
+        return $data ?? [];
     }
 
     /**

--- a/tests/ApiControllerInvalidJsonTest.php
+++ b/tests/ApiControllerInvalidJsonTest.php
@@ -1,0 +1,51 @@
+<?php
+namespace Framework\Core {
+    class Controller {}
+    class DBManager { public static function getDB() { return null; } }
+    class Auth { public static function currentUser() { return null; } }
+}
+
+namespace App\Api {
+    function file_get_contents($filename) {
+        if ($filename === 'php://input') {
+            return '{"invalid"';
+        }
+        return \file_get_contents($filename);
+    }
+}
+
+namespace Tests {
+    use PHPUnit\Framework\TestCase;
+
+    require_once __DIR__ . '/../application/Api/ApiController.php';
+
+    class ApiControllerInvalidJsonTest extends TestCase
+    {
+        public function testInvalidJsonTriggersError(): void
+        {
+            $controller = new class extends \App\Api\ApiController {
+                public $statusCode;
+                public $errorMessage;
+                public function __construct() {}
+                public function triggerGetJsonInput() {
+                    return $this->getJsonInput();
+                }
+                protected function respondError($statusCode, $message, $errors = null)
+                {
+                    $this->statusCode = $statusCode;
+                    $this->errorMessage = $message;
+                    throw new \Exception('error');
+                }
+            };
+
+            try {
+                $controller->triggerGetJsonInput();
+            } catch (\Exception $e) {
+                // Ignore exception to assert later
+            }
+
+            $this->assertEquals(400, $controller->statusCode);
+            $this->assertEquals('Invalid JSON body', $controller->errorMessage);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Validate JSON request bodies in `ApiController::getJsonInput` and return a 400 error for malformed JSON
- Add PHPUnit tests ensuring invalid JSON bodies trigger an error response

## Testing
- `phpunit tests/ApiControllerInvalidJsonTest.php`
- `phpunit tests/ChatMessagesUnauthorizedTest.php`
- `phpunit tests/ChatSendMessageUnauthorizedTest.php`
- `phpunit tests/ChatSearchMessagesTest.php`
- `phpunit tests/ChatUnreadCountTest.php`


------
https://chatgpt.com/codex/tasks/task_b_68a0bf5360f0832a965d31329caaec02