### PR TITLE
Return API responses instead of exiting

### DIFF
--- a/tests/ChatMessagesUnauthorizedTest.php
+++ b/tests/ChatMessagesUnauthorizedTest.php
@@ -15,14 +15,17 @@ namespace App\Api\Models {
     }
 }
 
-namespace App\Api {
-    abstract class ApiController {}
+namespace Framework\Core {
+    class Controller {}
+    class DBManager { public static function getDB() { return new class {}; } }
+    class Auth { public static function currentUser() { return null; } }
 }
 
 namespace Tests {
 
 use PHPUnit\Framework\TestCase;
 
+require_once __DIR__ . '/../application/Api/ApiController.php';
 require_once __DIR__ . '/../application/Api/Chat.php';
 
 class ChatMessagesUnauthorizedTest extends TestCase
@@ -30,33 +33,18 @@ class ChatMessagesUnauthorizedTest extends TestCase
     public function testMessagesReturns403WhenUserNotParticipant(): void
     {
         $chat = new class extends \App\Api\Chat {
-            public $statusCode;
             public function __construct() {}
             protected function authenticate($required = true)
             {
                 return ['user_id' => 99];
             }
-            protected function respondError($statusCode, $message, $errors = null)
-            {
-                $this->statusCode = $statusCode;
-                throw new \Exception('error');
-            }
-            protected function respondSuccess($data = null, $message = 'Success', $statusCode = 200)
-            {
-                $this->statusCode = $statusCode;
-                throw new \Exception('success');
-            }
         };
 
         $_GET['conversation_id'] = 1;
 
-        try {
-            $chat->messages();
-        } catch (\Exception $e) {
-            // Ignore to allow assertions
-        }
+        $result = $chat->messages();
 
-        $this->assertEquals(403, $chat->statusCode);
+        $this->assertEquals(403, $result['status_code']);
         $this->assertTrue(\App\Api\Models\ConversationParticipantModel::$called);
     }
 }

--- a/tests/ChatSearchMessagesTest.php
+++ b/tests/ChatSearchMessagesTest.php
@@ -16,14 +16,17 @@ namespace App\Api\Models {
     }
 }
 
-namespace App\Api {
-    abstract class ApiController {}
+namespace Framework\Core {
+    class Controller {}
+    class DBManager { public static function getDB() { return new class {}; } }
+    class Auth { public static function currentUser() { return null; } }
 }
 
 namespace Tests {
 
 use PHPUnit\Framework\TestCase;
 
+require_once __DIR__ . '/../application/Api/ApiController.php';
 require_once __DIR__ . '/../application/Api/Chat.php';
 
 class ChatSearchMessagesTest extends TestCase
@@ -40,27 +43,16 @@ class ChatSearchMessagesTest extends TestCase
         $_GET['conversation_id'] = 5;
 
         $chat = new class extends \App\Api\Chat {
-            public $statusCode;
             public function __construct() {}
             protected function authenticate($required = true)
             {
                 return ['user_id' => 99];
             }
-            protected function respondError($statusCode, $message, $errors = null)
-            {
-                $this->statusCode = $statusCode;
-                throw new \Exception('error');
-            }
-            protected function respondSuccess($data = null, $message = 'Success', $statusCode = 200)
-            {
-                $this->statusCode = $statusCode;
-                return $data;
-            }
         };
-        $chat->searchMessages();
+        $result = $chat->searchMessages();
 
         $this->assertEquals('searchConversationMessages', \App\Api\Models\MessageModel::$lastCalled['method']);
-        $this->assertEquals(200, $chat->statusCode);
+        $this->assertEquals(200, $result['status_code']);
     }
 
     public function testSearchMessagesWithoutConversationIdCallsUserMethod(): void
@@ -68,27 +60,16 @@ class ChatSearchMessagesTest extends TestCase
         $_GET['q'] = 'hello';
 
         $chat = new class extends \App\Api\Chat {
-            public $statusCode;
             public function __construct() {}
             protected function authenticate($required = true)
             {
                 return ['user_id' => 99];
             }
-            protected function respondError($statusCode, $message, $errors = null)
-            {
-                $this->statusCode = $statusCode;
-                throw new \Exception('error');
-            }
-            protected function respondSuccess($data = null, $message = 'Success', $statusCode = 200)
-            {
-                $this->statusCode = $statusCode;
-                return $data;
-            }
         };
-        $chat->searchMessages();
+        $result = $chat->searchMessages();
 
         $this->assertEquals('searchUserMessages', \App\Api\Models\MessageModel::$lastCalled['method']);
-        $this->assertEquals(200, $chat->statusCode);
+        $this->assertEquals(200, $result['status_code']);
     }
 }
 }

--- a/tests/ChatUnreadCountTest.php
+++ b/tests/ChatUnreadCountTest.php
@@ -24,14 +24,17 @@ namespace App\Api\Models {
     }
 }
 
-namespace App\Api {
-    abstract class ApiController {}
+namespace Framework\Core {
+    class Controller {}
+    class DBManager { public static function getDB() { return new class {}; } }
+    class Auth { public static function currentUser() { return null; } }
 }
 
 namespace Tests {
 
 use PHPUnit\Framework\TestCase;
 
+require_once __DIR__ . '/../application/Api/ApiController.php';
 require_once __DIR__ . '/../application/Api/Chat.php';
 
 class ChatUnreadCountTest extends TestCase
@@ -46,33 +49,20 @@ class ChatUnreadCountTest extends TestCase
     public function testUnreadCountUsesAggregateMethod(): void
     {
         $chat = new class extends \App\Api\Chat {
-            public $statusCode;
-            public $data;
             public function __construct() {}
             protected function authenticate($required = true)
             {
                 return ['user_id' => 99];
             }
-            protected function respondError($statusCode, $message, $errors = null)
-            {
-                $this->statusCode = $statusCode;
-                throw new \Exception('error');
-            }
-            protected function respondSuccess($data = null, $message = 'Success', $statusCode = 200)
-            {
-                $this->statusCode = $statusCode;
-                $this->data = $data;
-                return $data;
-            }
         };
 
-        $chat->unreadCount();
+        $result = $chat->unreadCount();
 
         $this->assertTrue(\App\Api\Models\ConversationModel::$totalCalled);
         $this->assertFalse(\App\Api\Models\ConversationModel::$getUserCalled);
         $this->assertFalse(\App\Api\Models\ConversationModel::$getUnreadCalled);
-        $this->assertEquals(200, $chat->statusCode);
-        $this->assertEquals(150, $chat->data['unread_count']);
+        $this->assertEquals(200, $result['status_code']);
+        $this->assertEquals(150, $result['data']['unread_count']);
     }
 }
 }


### PR DESCRIPTION
## Summary
- Refactor `ApiController` helpers to build response arrays rather than echoing and exiting
- Update Chat and other API controllers to return these arrays and add auth/validation checks
- Adjust unit tests to consume returned data

## Testing
- `phpunit tests/ChatMessagesUnauthorizedTest.php`
- `phpunit tests/ChatSendMessageUnauthorizedTest.php`
- `phpunit tests/ChatSearchMessagesTest.php`
- `phpunit tests/ChatUnreadCountTest.php`


------
https://chatgpt.com/codex/tasks/task_b_68a0bf57f76c832a823ce46d81571c73