### PR TITLE
Use model method for username uniqueness check

### DIFF
--- a/application/Api/User.php
+++ b/application/Api/User.php
@@ -89,13 +89,7 @@ class User extends ApiController
         foreach ($allowedFields as $field) {
             if (isset($data[$field])) {
                 if ($field === 'username' && !empty($data[$field])) {
-                    // Check username uniqueness
-                    $existing = $this->db->query(
-                        "SELECT id FROM users WHERE username = ? AND id != ? AND deleted_at IS NULL",
-                        [$data[$field], $id]
-                    )->fetchArray();
-
-                    if ($existing) {
+                    if (UserModel::usernameExists($data[$field], $id)) {
                         $this->respondError(400, 'Username already taken');
                     }
 


### PR DESCRIPTION
## Summary
- rely on `UserModel::usernameExists` to validate username uniqueness in API update
- remove direct SQL query for username checks

## Testing
- `phpunit tests` *(fails: Cannot declare class App\Api\ApiController, because the name is already in use)*

------
https://chatgpt.com/codex/tasks/task_b_68a1f202da3c832a806fc3b8a8eed46f