### PR TITLE
Rename GetUsers to getUsers in user model

### DIFF
--- a/application/Api/Models/UserModel.php
+++ b/application/Api/Models/UserModel.php
@@ -15,7 +15,7 @@ class UserModel extends Model
      * @param array $params bound params for WHERE
      * @return array { items, item_count, page_number, item_limit }
      */
-    public static function GetUsers(string $baseQuery, array $params = []): array
+    public static function getUsers(string $baseQuery, array $params = []): array
     {
         $db = static::db();
         return $db->dataQuery($baseQuery, $params);

--- a/application/Api/User.php
+++ b/application/Api/User.php
@@ -33,7 +33,7 @@ class User extends ApiController
                   FROM users {$whereClause} 
                   ORDER BY created_at DESC";
 
-        $result = UserModel::GetUsers($query, $params);
+        $result = UserModel::getUsers($query, $params);
 
         $this->respondPaginated(
             $result['items'],


### PR DESCRIPTION
## Summary
- rename GetUsers method to getUsers in user model
- update user controller to call getUsers

## Testing
- `php -l application/Api/Models/UserModel.php`
- `php -l application/Api/User.php`
- `phpunit tests` *(fails: Cannot declare class App\Api\ApiController, because the name is already in use)*

------
https://chatgpt.com/codex/tasks/task_b_68a20a2b59d8832ab3d0c2ee3a277224