### PR TITLE
Rename user API methods to camelCase

### DIFF
--- a/API_DOCUMENTATION.md
+++ b/API_DOCUMENTATION.md
@@ -14,7 +14,7 @@ https://yourdomain.com/api/
 
 ## Authentication
 
-All API endpoints (except auth endpoints) require Bearer token authentication.
+All API endpoints (except login and register) require Bearer token authentication.
 
 ### Headers
 
@@ -27,7 +27,7 @@ Content-Type: application/json
 
 ## Authentication Endpoints
 
-### POST /api/auth/login
+### POST /api/user/login
 
 Login user and get access token.
 
@@ -62,7 +62,7 @@ Login user and get access token.
 }
 ```
 
-### POST /api/auth/register
+### POST /api/user/register
 
 Register a new user.
 
@@ -78,15 +78,15 @@ Register a new user.
 }
 ```
 
-### POST /api/auth/logout
+### POST /api/user/logout
 
 Logout and revoke access token.
 
-### POST /api/auth/refresh
+### POST /api/user/refresh
 
 Refresh access token.
 
-### GET /api/auth/me
+### GET /api/user/me
 
 Get current authenticated user information.
 
@@ -126,7 +126,7 @@ Update user profile.
 
 Soft delete user account.
 
-### POST /api/user/{id}/upload-avatar
+### POST /api/user/{id}/uploadAvatar
 
 Upload user avatar image.
 

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ Configuration values are loaded from `.env.local`. Important options include:
 #### User Registration
 
 ```bash
-curl -X POST http://your-domain.com/api/user/Register \
+curl -X POST http://your-domain.com/api/user/register \
   -H "Content-Type: application/json" \
   -d '{
     "name": "John Doe",
@@ -115,7 +115,7 @@ curl -X POST http://your-domain.com/api/user/Register \
 #### User Login
 
 ```bash
-curl -X POST http://your-domain.com/api/user/Login \
+curl -X POST http://your-domain.com/api/user/login \
   -H "Content-Type: application/json" \
   -d '{
     "email": "john@example.com",
@@ -141,11 +141,11 @@ curl -X POST http://your-domain.com/api/message \
 
 | Method | Endpoint             | Description                  |
 | ------ | -------------------- | ---------------------------- |
-| POST   | `/api/user/Register` | Register new user            |
-| POST   | `/api/user/Login`    | User login                   |
-| POST   | `/api/user/Logout`   | User logout                  |
-| POST   | `/api/user/Refresh`  | Refresh authentication token |
-| GET    | `/api/user/Me`       | Get current user info        |
+| POST   | `/api/user/register` | Register new user            |
+| POST   | `/api/user/login`    | User login                   |
+| POST   | `/api/user/logout`   | User logout                  |
+| POST   | `/api/user/refresh`  | Refresh authentication token |
+| GET    | `/api/user/me`       | Get current user info        |
 
 ### User Management
 
@@ -155,8 +155,8 @@ curl -X POST http://your-domain.com/api/message \
 | GET    | `/api/user/{id}`              | Get user by ID         |
 | PUT    | `/api/user/{id}`              | Update user profile    |
 | DELETE | `/api/user/{id}`              | Delete user account    |
-| GET    | `/api/user/Search`            | Search users           |
-| POST   | `/api/user/{id}/UploadAvatar` | Upload user avatar     |
+| GET    | `/api/user/search`            | Search users           |
+| POST   | `/api/user/{id}/uploadAvatar` | Upload user avatar     |
 
 ### Conversations
 

--- a/application/Api/User.php
+++ b/application/Api/User.php
@@ -12,7 +12,7 @@ class User extends ApiController
     /**
      * GET /api/user - List all users with pagination and search
      */
-    public function Index()
+    public function index()
     {
         $search = $_GET['search'] ?? '';
 
@@ -47,7 +47,7 @@ class User extends ApiController
     /**
      * GET /api/user/{id} - Get a specific user
      */
-    public function Show($id = null)
+    public function show($id = null)
     {
         if (!$id) {
             $this->respondError(400, 'User ID is required');
@@ -67,7 +67,7 @@ class User extends ApiController
     /**
      * PUT /api/user/{id} - Update a user
      */
-    public function Update($id = null)
+    public function update($id = null)
     {
         if (!$id) {
             $this->respondError(400, 'User ID is required');
@@ -121,7 +121,7 @@ class User extends ApiController
     /**
      * DELETE /api/user/{id} - Soft delete a user
      */
-    public function Delete($id = null)
+    public function delete($id = null)
     {
         if (!$id) {
             $this->respondError(400, 'User ID is required');
@@ -157,9 +157,9 @@ class User extends ApiController
     }
 
     /**
-     * POST /api/user/{id}/UploadAvatar - Upload user avatar
+     * POST /api/user/{id}/uploadAvatar - Upload user avatar
      */
-    public function UploadAvatar($id = null)
+    public function uploadAvatar($id = null)
     {
         if (!$id) {
             $this->respondError(400, 'User ID is required');
@@ -232,9 +232,9 @@ class User extends ApiController
     }
 
     /**
-     * GET /api/user/Search - Search users (for adding to conversations)
+     * GET /api/user/search - Search users (for adding to conversations)
      */
-    public function Search()
+    public function search()
     {
         $query = $_GET['q'] ?? '';
         $limit = min((int)($_GET['limit'] ?? 10), 50);
@@ -251,9 +251,9 @@ class User extends ApiController
     }
 
     /**
-     * GET /api/user/Me - Get current authenticated user info
+     * GET /api/user/me - Get current authenticated user info
      */
-    public function Me()
+    public function me()
     {
         $user = $this->authenticate();
 
@@ -267,9 +267,9 @@ class User extends ApiController
     }
 
     /**
-     * POST /api/user/Login - User login (merged from Auth controller)
+     * POST /api/user/login - User login (merged from Auth controller)
      */
-    public function Login()
+    public function login()
     {
         $data = $this->getJsonInput();
         $this->validateRequired($data, ['email', 'password']);
@@ -316,9 +316,9 @@ class User extends ApiController
     }
 
     /**
-     * POST /api/user/Register - User registration (merged from Auth controller)
+     * POST /api/user/register - User registration (merged from Auth controller)
      */
-    public function Register()
+    public function register()
     {
         $data = $this->getJsonInput();
         $this->validateRequired($data, ['name', 'email', 'username', 'password']);
@@ -373,9 +373,9 @@ class User extends ApiController
     }
 
     /**
-     * POST /api/user/Logout - User logout (merged from Auth controller)
+     * POST /api/user/logout - User logout (merged from Auth controller)
      */
-    public function Logout()
+    public function logout()
     {
         $user = $this->authenticate();
         $token = $this->getAuthToken();
@@ -388,9 +388,9 @@ class User extends ApiController
     }
 
     /**
-     * POST /api/user/Refresh - Refresh token (merged from Auth controller)
+     * POST /api/user/refresh - Refresh token (merged from Auth controller)
      */
-    public function Refresh()
+    public function refresh()
     {
         $user = $this->authenticate();
 

--- a/framework/core/Framework.php
+++ b/framework/core/Framework.php
@@ -4,7 +4,7 @@ class Framework
 {
 
     private static $defaultController = 'Home';
-    private static $defaultMethod = 'Index';
+    private static $defaultMethod = 'index';
     private static $currentController;
     private static $currentMethod;
     private static $currentParams = [];


### PR DESCRIPTION
## Summary
- rename User API methods to camelCase and adjust documentation
- switch framework default method to `index`

## Testing
- `phpunit tests` *(fails: Cannot declare class App\Api\ApiController)*

------
https://chatgpt.com/codex/tasks/task_b_68a21114824c832aa05e7fc3f8a2221d