### PR TITLE
Refactor auth to use models and return token on login

### DIFF
--- a/application/Api/ApiController.php
+++ b/application/Api/ApiController.php
@@ -48,15 +48,7 @@ abstract class ApiController extends Controller
      */
     protected function authenticate($required = true)
     {
-        $user = CoreAuth::currentUser();
-
-        if (!$user) {
-            if ($required) {
-                $this->respondError(401, 'Authentication token required or invalid');
-            }
-            return null;
-        }
-
+        $user = $required ? CoreAuth::requireAuth() : CoreAuth::currentUser();
         $this->currentUser = $user;
         return $user;
     }

--- a/application/Api/Models/AuthTokenModel.php
+++ b/application/Api/Models/AuthTokenModel.php
@@ -35,7 +35,8 @@ class AuthTokenModel extends Model
         $db = static::db();
 
         return $db->query(
-            "SELECT at.*, u.id as user_id, u.name, u.email, u.username"
+            "SELECT at.id as session_id, at.token, at.user_id, at.ip_address, at.user_agent,"
+            . " at.device_id, at.created_at, at.expires_at, u.name, u.email, u.username, u.avatar_url"
             . " FROM auth_tokens at"
             . " JOIN users u ON at.user_id = u.id"
             . " WHERE at.token = ?"

--- a/application/Api/Models/UserModel.php
+++ b/application/Api/Models/UserModel.php
@@ -86,8 +86,15 @@ class UserModel extends Model
             return null;
         }
 
-        $user = static::find((int) $tokenData['user_id']);
-        return $user?->toArray();
+        return [
+            'user_id'    => (int) $tokenData['user_id'],
+            'name'       => $tokenData['name'],
+            'email'      => $tokenData['email'],
+            'username'   => $tokenData['username'],
+            'avatar_url' => $tokenData['avatar_url'] ?? null,
+            'session_id' => (int) $tokenData['session_id'],
+            'token'      => $tokenData['token'],
+        ];
     }
 
     /**

--- a/application/Api/User.php
+++ b/application/Api/User.php
@@ -275,14 +275,16 @@ class User extends ApiController
         $this->validateRequired($data, ['email', 'password']);
 
         // Try to find user by email or username
-        $user = UserModel::getUserByEmail($data['email']);
-        if (!$user) {
-            $user = UserModel::getUserByUsername($data['email']);
+        $userModel = UserModel::getUserByEmail($data['email']);
+        if (!$userModel) {
+            $userModel = UserModel::getUserByUsername($data['email']);
         }
 
-        if (!$user || !password_verify($data['password'], $user['password'])) {
+        if (!$userModel || !password_verify($data['password'], $userModel->password)) {
             $this->respondError(401, 'Invalid credentials');
         }
+
+        $user = $userModel->toArray();
 
         // Register/update device if provided
         if (!empty($data['device_id'])) {

--- a/framework/core/Auth.php
+++ b/framework/core/Auth.php
@@ -3,6 +3,7 @@
 namespace Framework\Core;
 
 use Framework\Core\DBManager;
+use App\Api\Models\UserModel;
 
 class Auth
 {
@@ -13,25 +14,18 @@ class Auth
     public static $sessionId;
     public static $token;
     public static $authType;
+    private static $currentUser;
 
     /**
-     * Simple permission check for chat system
-     * In chat context, users can access their own data and conversations they participate in
+     * Simple permission check for chat system.
+     * Currently just verifies that a valid auth token is present.
      */
     public static function checkPermission($section, $controller, $action)
     {
-        // For chat system, we use simple ownership-based permissions
-        // More complex permissions can be added later if needed
+        // Ensure user is authenticated globally
+        self::requireAuth();
 
-        $user = self::currentUser();
-        if (!$user) {
-            http_response_code(401);
-            echo json_encode(['error' => 401, 'msg' => 'Authentication required']);
-            exit();
-        }
-
-        // Basic permission check - users can access their own resources
-        // Specific resource-level permissions are handled in individual controllers
+        // Additional resource-level checks can be added here in the future
         return true;
     }
 
@@ -47,28 +41,22 @@ class Auth
 
     /**
      * Public helper to get the current authenticated user from Bearer token.
-     * Returns an associative array with keys: user_id, name, email, username, session_id, token
-     * or null if not authenticated.
+     * Returns an associative array with keys: user_id, name, email, username,
+     * avatar_url, session_id and token or null if not authenticated.
      */
     public static function currentUser(): ?array
     {
-        $db = DBManager::getDB();
+        if (self::$currentUser !== null) {
+            return self::$currentUser;
+        }
 
         $token = null;
         // Try common Authorization headers (case-insensitive)
         $headers = function_exists('getallheaders') ? getallheaders() : [];
-        foreach (
-            [
-                'Authorization',
-                'authorization',
-                'AUTHORIZATION'
-            ] as $h
-        ) {
-            if (!empty($headers[$h])) {
-                if (preg_match('/Bearer\s+(.*)$/i', $headers[$h], $m)) {
-                    $token = $m[1];
-                    break;
-                }
+        foreach (['Authorization', 'authorization', 'AUTHORIZATION'] as $h) {
+            if (!empty($headers[$h]) && preg_match('/Bearer\s+(.*)$/i', $headers[$h], $m)) {
+                $token = $m[1];
+                break;
             }
         }
         // Fallback to server var
@@ -83,35 +71,17 @@ class Auth
             return null;
         }
 
-        // Query auth_tokens table as per the current schema
-        $userQuery = $db->query(
-            "SELECT u.id, u.name, u.email, u.username, at.id as session_id
-             FROM auth_tokens at
-             JOIN users u ON u.id = at.user_id
-             WHERE at.token = ?
-             AND at.revoked_at IS NULL
-             AND (at.expires_at IS NULL OR at.expires_at > NOW())",
-            [$token]
-        );
-
-        if (!empty($userQuery) && $userQuery->numRows() > 0) {
-            $uinfo = $userQuery->fetchArray();
+        $uinfo = UserModel::validateToken($token);
+        if ($uinfo) {
             self::$sessionId = $uinfo['session_id'];
-            self::$token = $token;
-            self::$userId = $uinfo['id'];
+            self::$token = $uinfo['token'];
+            self::$userId = $uinfo['user_id'];
             self::$name = $uinfo['name'];
             self::$email = $uinfo['email'];
             self::$username = $uinfo['username'];
             self::$authType = 'token';
-
-            return [
-                'user_id' => $uinfo['id'],
-                'name' => $uinfo['name'],
-                'email' => $uinfo['email'],
-                'username' => $uinfo['username'],
-                'session_id' => $uinfo['session_id'],
-                'token' => $token,
-            ];
+            self::$currentUser = $uinfo;
+            return $uinfo;
         }
 
         return null;
@@ -125,32 +95,35 @@ class Auth
 
     private static function authorizeWithToken($token)
     {
-        $db = DBManager::getDB();
-
-        // Query auth_tokens table as per the current schema
-        $userQuery = $db->query(
-            "SELECT u.id, u.name, u.email, u.username, at.id as session_id
-             FROM auth_tokens at
-             JOIN users u ON u.id = at.user_id
-             WHERE at.token = ? 
-             AND at.revoked_at IS NULL 
-             AND (at.expires_at IS NULL OR at.expires_at > NOW())",
-            [$token]
-        );
-
-        if (!empty($userQuery) && $userQuery->numRows() > 0) {
-            $uinfo = $userQuery->fetchArray();
+        $uinfo = UserModel::validateToken($token);
+        if ($uinfo) {
             self::$sessionId = $uinfo['session_id'];
-            self::$token = $token;
-            self::$userId = $uinfo['id'];
+            self::$token = $uinfo['token'];
+            self::$userId = $uinfo['user_id'];
             self::$name = $uinfo['name'];
             self::$email = $uinfo['email'];
             self::$username = $uinfo['username'];
             self::$authType = 'token';
+            self::$currentUser = $uinfo;
             return true;
         }
 
         return false;
+    }
+
+    /**
+     * Require authentication and return the current user.
+     * Sends a 401 response and exits if not authenticated.
+     */
+    public static function requireAuth(): array
+    {
+        $user = self::currentUser();
+        if (!$user) {
+            http_response_code(401);
+            echo json_encode(['error' => 401, 'msg' => 'Authentication required']);
+            exit();
+        }
+        return $user;
     }
 
     /**
@@ -191,7 +164,7 @@ class Auth
 
         $db = DBManager::getDB();
         $result = $db->query(
-            "SELECT COUNT(*) as count FROM conversation_participants 
+            "SELECT COUNT(*) as count FROM conversation_participants
              WHERE conversation_id = ? AND user_id = ?",
             [$conversationId, $currentUserId]
         );
@@ -200,3 +173,4 @@ class Auth
         return $row && $row['count'] > 0;
     }
 }
+


### PR DESCRIPTION
## Summary
- use AuthTokenModel and UserModel to resolve bearer tokens
- return auth token with user info during login
- add global `requireAuth` helper for framework-wide auth checks

## Testing
- `phpunit tests/ApiControllerInvalidJsonTest.php`
- `phpunit tests/ChatMessagesUnauthorizedTest.php`
- `phpunit tests/ChatSendMessageUnauthorizedTest.php`


------
https://chatgpt.com/codex/tasks/task_b_68a34935e288832aa76205225dda9cc1