### PR TITLE
Use paginated responses for chat messages

### DIFF
--- a/API_DOCUMENTATION.md
+++ b/API_DOCUMENTATION.md
@@ -394,8 +394,35 @@ Get messages for conversation.
 **Query Parameters:**
 
 - `conversation_id` (int): Required
-- `limit` (int): Max messages
-- `offset` (int): Skip messages
+- `limit` (int): Max messages (default: 50, max: 100)
+- `offset` (int): Skip messages (used with limit to calculate page)
+
+**Response:**
+
+```json
+{
+  "success": true,
+  "message": "Messages retrieved successfully",
+  "data": {
+    "items": [
+      {
+        "id": 1,
+        "conversation_id": 10,
+        "sender_id": 2,
+        "content": "Hello"
+      }
+    ],
+    "pagination": {
+      "current_page": 1,
+      "per_page": 50,
+      "total": 123,
+      "total_pages": 3,
+      "has_next": true,
+      "has_prev": false
+    }
+  }
+}
+```
 
 ### POST /api/chat/create-conversation
 

--- a/application/Api/Chat.php
+++ b/application/Api/Chat.php
@@ -108,6 +108,9 @@ class Chat extends ApiController
         $conversationId = $_GET['conversation_id'] ?? null;
         $limit = min((int)($_GET['limit'] ?? 50), 100);
         $offset = (int)($_GET['offset'] ?? 0);
+        if ($limit <= 0) {
+            $limit = 50;
+        }
 
         if (!$conversationId) {
             $this->respondError(400, 'Conversation ID is required');
@@ -120,8 +123,10 @@ class Chat extends ApiController
 
         try {
             $messages = MessageModel::getConversationMessagesWithDetails($conversationId, $limit, $offset);
+            $total = MessageModel::getConversationMessageCount($conversationId);
+            $page = (int) floor($offset / $limit) + 1;
 
-            $this->respondSuccess($messages, 'Messages retrieved successfully');
+            $this->respondPaginated($messages, $total, $page, $limit, 'Messages retrieved successfully');
         } catch (\Exception $e) {
             Util::log($e->getMessage(), [
                 'user_id' => $user['user_id'],

--- a/application/Api/Models/MessageModel.php
+++ b/application/Api/Models/MessageModel.php
@@ -148,6 +148,21 @@ class MessageModel extends Model
     }
 
     /**
+     * Get total message count for a conversation
+     */
+    public static function getConversationMessageCount($conversationId)
+    {
+        $db = static::db();
+
+        $result = $db->query(
+            "SELECT COUNT(*) as count FROM messages WHERE conversation_id = ?",
+            [$conversationId]
+        )->fetchArray();
+
+        return $result['count'];
+    }
+
+    /**
      * Mark message as read by user
      */
     public static function markAsRead($messageId, $userId)


### PR DESCRIPTION
## Summary
- Return messages via `respondPaginated` with page metadata
- Add `MessageModel::getConversationMessageCount` helper
- Document paginated response for `/api/chat/messages`

## Testing
- `php -l application/Api/Chat.php`
- `php -l application/Api/Models/MessageModel.php`


------
https://chatgpt.com/codex/tasks/task_b_68a50cb9d08c832a8ef9c7adb17bfcf9