### PR TITLE
Add paginated conversation listing with unread counts

### DIFF
--- a/API_DOCUMENTATION.md
+++ b/API_DOCUMENTATION.md
@@ -356,7 +356,38 @@ Search messages across all conversations.
 
 ### GET /api/chat/conversations
 
-Get user's conversations.
+Get user's conversations with pagination.
+
+**Query Parameters:**
+
+- `page` (int): Page number
+- `per_page` (int): Items per page
+
+**Response:**
+
+```json
+{
+  "success": true,
+  "message": "Conversations retrieved successfully",
+  "data": {
+    "items": [
+      {
+        "id": 1,
+        "title": "Project Team",
+        "unread_count": 2
+      }
+    ],
+    "pagination": {
+      "current_page": 1,
+      "per_page": 20,
+      "total": 40,
+      "total_pages": 2,
+      "has_next": true,
+      "has_prev": false
+    }
+  }
+}
+```
 
 ### POST /api/chat/send-message
 

--- a/application/Api/Chat.php
+++ b/application/Api/Chat.php
@@ -20,12 +20,17 @@ class Chat extends ApiController
         $user = $this->authenticate();
         $page = (int)($_GET['page'] ?? 1);
         $perPage = min((int)($_GET['per_page'] ?? 20), 100);
-        $offset = ($page - 1) * $perPage;
 
         try {
-            $conversations = ConversationModel::getUserConversations($user['user_id'], $perPage, $offset);
+            $result = ConversationModel::getUserConversationsPaginated($user['user_id'], $page, $perPage);
 
-            $this->respondSuccess($conversations, 'Conversations retrieved successfully');
+            $this->respondPaginated(
+                $result['items'],
+                $result['total'],
+                $page,
+                $perPage,
+                'Conversations retrieved successfully'
+            );
         } catch (\Exception $e) {
             Util::log($e->getMessage(), [
                 'user_id' => $user['user_id'],

--- a/application/Api/Conversation.php
+++ b/application/Api/Conversation.php
@@ -18,32 +18,23 @@ class Conversation extends ApiController
         $user = $this->authenticate();
 
         try {
-            // Use dataQuery for automatic pagination
-            $query = "SELECT c.*, 
-                             cp.last_read_message_id,
-                             cp.role,
-                             (SELECT COUNT(*) FROM conversation_participants cp2 WHERE cp2.conversation_id = c.id) as participant_count,
-                             (SELECT m.content FROM messages m WHERE m.conversation_id = c.id ORDER BY m.created_at DESC LIMIT 1) as last_message,
-                             (SELECT m.created_at FROM messages m WHERE m.conversation_id = c.id ORDER BY m.created_at DESC LIMIT 1) as last_message_time,
-                             (SELECT u.name FROM messages m JOIN users u ON m.sender_id = u.id WHERE m.conversation_id = c.id ORDER BY m.created_at DESC LIMIT 1) as last_sender_name
-                      FROM conversations c
-                      JOIN conversation_participants cp ON c.id = cp.conversation_id
-                      WHERE cp.user_id = ?
-                      ORDER BY last_message_time IS NULL, last_message_time DESC";
+            $page = (int)($_GET['page'] ?? 1);
+            $perPage = min((int)($_GET['per_page'] ?? 20), 100);
 
-            $result = ConversationModel::getUserConversationsPaginated($query, [$user['user_id']]);
+            $result = ConversationModel::getUserConversationsPaginated($user['user_id'], $page, $perPage);
 
             $this->respondPaginated(
                 $result['items'],
-                $result['item_count'],
-                $result['page_number'],
-                $result['item_limit'],
+                $result['total'],
+                $page,
+                $perPage,
                 'Conversations retrieved successfully'
             );
         } catch (\Exception $e) {
             $this->respondError(500, 'Failed to retrieve conversations');
         }
     }
+
 
     /**
      * POST /api/conversation - Create a new conversation


### PR DESCRIPTION
## Summary
- Add ConversationModel::getUserConversationsPaginated to return conversations with unread counts and total count
- Update Chat and Conversation controllers to use paginated conversation listing and respondPaginated
- Document paginated chat conversation response in API docs

## Testing
- `php -l application/Api/Models/ConversationModel.php`
- `php -l application/Api/Chat.php`
- `php -l application/Api/Conversation.php`


------
https://chatgpt.com/codex/tasks/task_b_68a50dfedb08832aa42bbd39a0ca5b40