### PR TITLE
Add model relationships and refactor API queries

### DIFF
--- a/application/Api/Device.php
+++ b/application/Api/Device.php
@@ -46,7 +46,8 @@ class Device extends ApiController
         $user = $this->authenticate();
 
         try {
-            $devices = DeviceModel::getUserDevices($user['user_id']);
+            $userModel = UserModel::find($user['user_id']);
+            $devices = $userModel ? array_map(fn($d) => $d->toArray(), $userModel->devices()) : [];
 
             $this->respondSuccess($devices, 'Devices retrieved successfully');
         } catch (\Exception $e) {

--- a/application/Api/Models/DeviceModel.php
+++ b/application/Api/Models/DeviceModel.php
@@ -3,6 +3,7 @@
 namespace App\Api\Models;
 
 use Framework\Core\Model;
+use App\Api\Models\UserModel;
 
 class DeviceModel extends Model
 {
@@ -11,6 +12,11 @@ class DeviceModel extends Model
         'user_id', 'device_id', 'platform', 'fcm_token', 'device_name',
         'app_version', 'os_version', 'last_active_at', 'created_at', 'updated_at'
     ];
+
+    public function user(): ?UserModel
+    {
+        return $this->belongsTo(UserModel::class);
+    }
 
     public static function registerDevice($userId, $deviceId, $platform, $fcmToken = null, $deviceName = null, $appVersion = null, $osVersion = null)
     {

--- a/application/Api/Models/MessageAttachmentModel.php
+++ b/application/Api/Models/MessageAttachmentModel.php
@@ -13,6 +13,16 @@ class MessageAttachmentModel extends Model
     ];
     protected bool $timestamps = false;
 
+    public function message(): ?MessageModel
+    {
+        return $this->belongsTo(MessageModel::class);
+    }
+
+    public function uploader(): ?UserModel
+    {
+        return $this->belongsTo(UserModel::class, 'uploader_id');
+    }
+
     /**
      * Add attachment to a message (alias for createAttachment)
      */

--- a/application/Api/Models/MessageModel.php
+++ b/application/Api/Models/MessageModel.php
@@ -20,6 +20,11 @@ class MessageModel extends Model
         return $this->hasMany(MessageAttachmentModel::class, 'message_id');
     }
 
+    public function conversation(): ?ConversationModel
+    {
+        return $this->belongsTo(ConversationModel::class, 'conversation_id');
+    }
+
     public static function createMessage($conversationId, $senderId, $content, $messageType = 'text', $parentId = null)
     {
         $message = new static([

--- a/application/Api/Services/ChatService.php
+++ b/application/Api/Services/ChatService.php
@@ -42,19 +42,17 @@ class ChatService
             return null;
         }
 
-        $tokenData = AuthTokenModel::validateToken($token);
+        $tokenModel = AuthTokenModel::validateToken($token);
 
-        if (!$tokenData) {
+        if (!$tokenModel) {
             return null;
         }
 
-        // Get user details
-        $user = UserModel::find($tokenData['user_id']);
-
+        $user = $tokenModel->user;
         if ($user) {
-            $user = $user->toArray();
-            $user['user_id'] = $user['id']; // For compatibility
-            return $user;
+            $data = $user->toArray();
+            $data['user_id'] = $user->id; // For compatibility
+            return $data;
         }
 
         return null;


### PR DESCRIPTION
## Summary
- define ORM relationships for auth tokens, devices, conversations, participants, messages, attachments, and users
- refactor token validation, device listing, and participant lookups to leverage new relations
- expose user tokens, devices, conversations, and messages through relationships

## Testing
- `php -l application/Api/Models/AuthTokenModel.php`
- `php -l application/Api/Models/DeviceModel.php`
- `php -l application/Api/Models/ConversationModel.php`
- `php -l application/Api/Models/ConversationParticipantModel.php`
- `php -l application/Api/Models/MessageModel.php`
- `php -l application/Api/Models/MessageAttachmentModel.php`
- `php -l application/Api/Models/UserModel.php`
- `php -l application/Api/Device.php`
- `php -l application/Api/Services/ChatService.php`


------
https://chatgpt.com/codex/tasks/task_b_68a5121a8964832aad428a59b77a99b6