### PR TITLE
Support IS NULL in model queries

### DIFF
--- a/application/Api/Models/UserModel.php
+++ b/application/Api/Models/UserModel.php
@@ -218,19 +218,10 @@ class UserModel extends Model
         if (empty($userIds)) {
             return [];
         }
-        $db = static::db();
-        $placeholders = implode(', ', array_fill(0, count($userIds), '?'));
-        $rows = $db->query(
-            "SELECT * FROM users WHERE id IN ({$placeholders}) AND deleted_at IS NULL",
-            $userIds
-        )->fetchAll() ?: [];
-
-        return array_map(function (array $row) {
-            $model = new static();
-            $model->attributes = $row;
-            $model->original = $row;
-            return $model;
-        }, $rows);
+        return static::where([
+            ['id', 'IN', $userIds],
+            ['deleted_at', 'IS', null],
+        ]);
     }
 
     /**

--- a/framework/core/Model.php
+++ b/framework/core/Model.php
@@ -508,6 +508,16 @@ abstract class Model
                     $parts[] = "{$col} IN ({$inList})";
                     break;
                 }
+                case 'IS': {
+                    if ($val === null) {
+                        $parts[] = "{$col} IS NULL";
+                        break;
+                    }
+                    $paramName = ':p' . $paramCounter++;
+                    $parts[] = "{$col} IS {$paramName}";
+                    $params[ltrim($paramName, ':')] = $val;
+                    break;
+                }
                 default:
                     throw new InvalidArgumentException("Unsupported operator: {$op}");
             }


### PR DESCRIPTION
## Summary
- handle `['col','IS',null]` in the ORM's `compileWhere`
- simplify `UserModel::getUsersByIds` using new `where` condition

## Testing
- `php -l framework/core/Model.php`
- `php -l application/Api/Models/UserModel.php`


------
https://chatgpt.com/codex/tasks/task_b_68a515258fb8832a980e95a32e0be692