### PR TITLE
Add query builder helpers and refactor user model

### DIFF
--- a/application/Api/Models/UserModel.php
+++ b/application/Api/Models/UserModel.php
@@ -167,15 +167,17 @@ class UserModel extends Model
      */
     public static function searchUsers($query, $limit = 10)
     {
-        $db = static::db();
+        $like = "%$query%";
 
-        return $db->query(
-            "SELECT id, name, username, email, avatar_url"
-            . " FROM users"
-            . " WHERE deleted_at IS NULL AND (name LIKE ? OR username LIKE ? OR email LIKE ?)"
-            . " LIMIT ?",
-            ["%$query%", "%$query%", "%$query%", $limit]
-        )->fetchAll();
+        return array_map(
+            fn($user) => $user->toArray(),
+            static::query()
+                ->select(['id', 'name', 'username', 'email', 'avatar_url'])
+                ->where([['deleted_at', 'IS', null]])
+                ->whereRaw('(name LIKE :q OR username LIKE :q OR email LIKE :q)', ['q' => $like])
+                ->limit($limit)
+                ->get()
+        );
     }
 
     /**
@@ -242,9 +244,9 @@ class UserModel extends Model
      */
     public static function getUserCount()
     {
-        $db = static::db();
-        $result = $db->query("SELECT COUNT(*) as count FROM users WHERE deleted_at IS NULL")->fetchArray();
-        return $result['count'];
+        return static::query()
+            ->where([['deleted_at', 'IS', null]])
+            ->count();
     }
 
     /**
@@ -299,15 +301,15 @@ class UserModel extends Model
      */
     public static function getRecentUsers($limit = 10)
     {
-        $db = static::db();
-        return $db->query(
-            "SELECT id, name, username, email, avatar_url, created_at"
-            . " FROM users"
-            . " WHERE deleted_at IS NULL"
-            . " ORDER BY created_at DESC"
-            . " LIMIT ?",
-            [$limit]
-        )->fetchAll();
+        return array_map(
+            fn($user) => $user->toArray(),
+            static::query()
+                ->select(['id', 'name', 'username', 'email', 'avatar_url', 'created_at'])
+                ->where([['deleted_at', 'IS', null]])
+                ->orderBy('created_at', 'DESC')
+                ->limit($limit)
+                ->get()
+        );
     }
 }
 

--- a/framework/core/Model.php
+++ b/framework/core/Model.php
@@ -34,6 +34,11 @@ abstract class Model
         return DBManager::getDB();
     }
 
+    public static function query(): QueryBuilder
+    {
+        return new QueryBuilder(static::db(), static::$table, static::class);
+    }
+
     public function __get(string $name): mixed
     {
         if (array_key_exists($name, $this->attributes)) {
@@ -451,7 +456,7 @@ abstract class Model
      *
      * @return array{0:string,1:array} [whereSql, params]
      */
-    protected static function compileWhere(array $conditions): array
+    public static function compileWhere(array $conditions): array
     {
         if ($conditions === []) {
             return ['', []];

--- a/framework/core/QueryBuilder.php
+++ b/framework/core/QueryBuilder.php
@@ -1,0 +1,120 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Framework\Core;
+
+class QueryBuilder
+{
+    private Database $db;
+    private string $table;
+    /** @var class-string<Model> */
+    private string $modelClass;
+    private array $columns = ['*'];
+    private array $conditions = [];
+    private array $rawConditions = [];
+    private array $orderBy = [];
+    private ?int $limit = null;
+    private ?int $offset = null;
+
+    public function __construct(Database $db, string $table, string $modelClass)
+    {
+        $this->db = $db;
+        $this->table = $table;
+        $this->modelClass = $modelClass;
+    }
+
+    public function select(array $columns): self
+    {
+        $this->columns = $columns;
+        return $this;
+    }
+
+    public function where(array $conditions): self
+    {
+        $this->conditions = array_merge($this->conditions, $conditions);
+        return $this;
+    }
+
+    public function whereRaw(string $sql, array $params = []): self
+    {
+        $this->rawConditions[] = ['sql' => $sql, 'params' => $params];
+        return $this;
+    }
+
+    public function orderBy(string $column, string $direction = 'ASC'): self
+    {
+        $this->orderBy[] = $column . ' ' . strtoupper($direction);
+        return $this;
+    }
+
+    public function limit(int $limit): self
+    {
+        $this->limit = $limit;
+        return $this;
+    }
+
+    public function offset(int $offset): self
+    {
+        $this->offset = $offset;
+        return $this;
+    }
+
+    private function buildWhere(): array
+    {
+        $sqlParts = [];
+        $params = [];
+
+        if ($this->conditions !== []) {
+            [$condSql, $condParams] = $this->modelClass::compileWhere($this->conditions);
+            if ($condSql !== '') {
+                $sqlParts[] = substr($condSql, 6); // remove leading 'WHERE '
+                $params = $condParams;
+            }
+        }
+
+        foreach ($this->rawConditions as $raw) {
+            $sqlParts[] = $raw['sql'];
+            $params = array_merge($params, $raw['params']);
+        }
+
+        if ($sqlParts === []) {
+            return ['', []];
+        }
+
+        return ['WHERE ' . implode(' AND ', $sqlParts), $params];
+    }
+
+    public function get(): array
+    {
+        [$whereSql, $params] = $this->buildWhere();
+        $sql = 'SELECT ' . implode(', ', $this->columns) . ' FROM ' . $this->table . ' ' . $whereSql;
+        if ($this->orderBy !== []) {
+            $sql .= ' ORDER BY ' . implode(', ', $this->orderBy);
+        }
+        if ($this->limit !== null) {
+            $sql .= ' LIMIT ' . $this->limit;
+        }
+        if ($this->offset !== null) {
+            $sql .= ' OFFSET ' . $this->offset;
+        }
+
+        $rows = $this->db->query($sql, $params)->fetchAll() ?: [];
+
+        return array_map(function (array $row) {
+            $model = new $this->modelClass();
+            $model->attributes = $row;
+            $model->original = $row;
+            return $model;
+        }, $rows);
+    }
+
+    public function count(): int
+    {
+        [$whereSql, $params] = $this->buildWhere();
+        $sql = 'SELECT COUNT(*) as count FROM ' . $this->table . ' ' . $whereSql;
+        $row = $this->db->query($sql, $params)->fetchArray();
+        return (int)($row['count'] ?? 0);
+    }
+}
+


### PR DESCRIPTION
## Summary
- add query builder with select, order, limit, offset, and count helpers
- use new helpers in UserModel for searching, counting, and listing users

## Testing
- `php -l framework/core/Model.php`
- `php -l framework/core/QueryBuilder.php`
- `php -l application/Api/Models/UserModel.php`


------
https://chatgpt.com/codex/tasks/task_b_68a523814cd8832ab7668135ec11f6b8