### PR TITLE
Introduce model collections for relationship serialization

### DIFF
--- a/application/Api/Device.php
+++ b/application/Api/Device.php
@@ -47,7 +47,7 @@ class Device extends ApiController
 
         try {
             $userModel = UserModel::find($user['user_id']);
-            $devices = $userModel ? array_map(fn($d) => $d->toArray(), $userModel->devices()) : [];
+            $devices = $userModel ? $userModel->devices()->toArray() : [];
 
             $this->respondSuccess($devices, 'Devices retrieved successfully');
         } catch (\Exception $e) {

--- a/application/Api/Models/ConversationParticipantModel.php
+++ b/application/Api/Models/ConversationParticipantModel.php
@@ -99,15 +99,17 @@ class ConversationParticipantModel extends Model
             return [];
         }
 
-        $participants = $conversation->participants();
-        return array_map(function ($user) {
-            $data = $user->toArray();
-            $pivot = $user->_pivot ?? [];
-            $data['role'] = $pivot['role'] ?? null;
-            $data['joined_at'] = $pivot['joined_at'] ?? null;
-            $data['last_read_message_id'] = $pivot['last_read_message_id'] ?? null;
-            return $data;
-        }, $participants);
+        $participants = $conversation->participants()->toArray();
+        $results = [];
+        foreach ($participants as $user) {
+            $pivot = $user['_pivot'] ?? [];
+            $user['role'] = $pivot['role'] ?? null;
+            $user['joined_at'] = $pivot['joined_at'] ?? null;
+            $user['last_read_message_id'] = $pivot['last_read_message_id'] ?? null;
+            unset($user['_pivot']);
+            $results[] = $user;
+        }
+        return $results;
     }
 
     public static function getParticipantRole($conversationId, $userId)

--- a/application/Api/Models/DeviceModel.php
+++ b/application/Api/Models/DeviceModel.php
@@ -3,6 +3,7 @@
 namespace App\Api\Models;
 
 use Framework\Core\Model;
+use Framework\Core\Collection;
 use App\Api\Models\UserModel;
 
 class DeviceModel extends Model
@@ -66,7 +67,7 @@ class DeviceModel extends Model
     {
         $devices = static::where(['user_id' => $userId]);
         usort($devices, fn($a, $b) => strcmp($b->last_active_at, $a->last_active_at));
-        return array_map(fn($d) => $d->toArray(), $devices);
+        return (new Collection($devices))->toArray();
     }
 
     public static function removeDevice($userId, $deviceId)

--- a/application/Api/Models/MessageAttachmentModel.php
+++ b/application/Api/Models/MessageAttachmentModel.php
@@ -79,7 +79,7 @@ class MessageAttachmentModel extends Model
             return [];
         }
         $attachments = $message->attachments;
-        return array_map(fn($a) => $a->toArray(), $attachments);
+        return $attachments->toArray();
     }
 
     public static function getAttachmentById($attachmentId)

--- a/application/Api/Models/MessageModel.php
+++ b/application/Api/Models/MessageModel.php
@@ -3,6 +3,7 @@
 namespace App\Api\Models;
 
 use Framework\Core\Model;
+use Framework\Core\Collection;
 
 class MessageModel extends Model
 {
@@ -15,7 +16,7 @@ class MessageModel extends Model
         return $this->belongsTo(UserModel::class, 'sender_id');
     }
 
-    public function attachments(): array
+    public function attachments(): Collection
     {
         return $this->hasMany(MessageAttachmentModel::class, 'message_id');
     }

--- a/application/Api/Models/UserModel.php
+++ b/application/Api/Models/UserModel.php
@@ -3,6 +3,7 @@
 namespace App\Api\Models;
 
 use Framework\Core\Model;
+use Framework\Core\Collection;
 use App\Api\Models\AuthTokenModel;
 use App\Api\Models\DeviceModel;
 use App\Api\Models\ConversationModel;
@@ -13,17 +14,17 @@ class UserModel extends Model
     protected static string $table = 'users';
     protected array $fillable = ['name', 'email', 'username', 'password', 'avatar_url', 'created_at', 'updated_at', 'deleted_at'];
 
-    public function tokens(): array
+    public function tokens(): Collection
     {
         return $this->hasMany(AuthTokenModel::class, 'user_id');
     }
 
-    public function devices(): array
+    public function devices(): Collection
     {
         return $this->hasMany(DeviceModel::class, 'user_id');
     }
 
-    public function conversations(): array
+    public function conversations(): Collection
     {
         return $this->belongsToMany(
             ConversationModel::class,
@@ -33,7 +34,7 @@ class UserModel extends Model
         );
     }
 
-    public function messages(): array
+    public function messages(): Collection
     {
         return $this->hasMany(MessageModel::class, 'sender_id');
     }

--- a/framework/core/Collection.php
+++ b/framework/core/Collection.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Framework\Core;
+
+use ArrayIterator;
+use ArrayAccess;
+use Countable;
+use IteratorAggregate;
+use Traversable;
+
+class Collection implements IteratorAggregate, ArrayAccess, Countable
+{
+    /** @var array<int|string, mixed> */
+    protected array $items;
+
+    public function __construct(array $items = [])
+    {
+        $this->items = $items;
+    }
+
+    public function getIterator(): Traversable
+    {
+        return new ArrayIterator($this->items);
+    }
+
+    public function offsetExists($offset): bool
+    {
+        return isset($this->items[$offset]);
+    }
+
+    public function offsetGet($offset): mixed
+    {
+        return $this->items[$offset];
+    }
+
+    public function offsetSet($offset, $value): void
+    {
+        if ($offset === null) {
+            $this->items[] = $value;
+        } else {
+            $this->items[$offset] = $value;
+        }
+    }
+
+    public function offsetUnset($offset): void
+    {
+        unset($this->items[$offset]);
+    }
+
+    public function count(): int
+    {
+        return count($this->items);
+    }
+
+    public function toArray(): array
+    {
+        return array_map(
+            fn($item) => $item instanceof Model ? $item->toArray() : $item,
+            $this->items
+        );
+    }
+}

--- a/framework/core/Model.php
+++ b/framework/core/Model.php
@@ -6,6 +6,7 @@ namespace Framework\Core;
 
 use InvalidArgumentException;
 use RuntimeException;
+use Framework\Core\Collection;
 
 abstract class Model
 {
@@ -75,11 +76,10 @@ abstract class Model
         foreach ($this->relations as $key => $relation) {
             if ($relation instanceof self) {
                 $data[$key] = $relation->toArray();
+            } elseif ($relation instanceof Collection) {
+                $data[$key] = $relation->toArray();
             } elseif (is_array($relation)) {
-                $data[$key] = array_map(
-                    fn($item) => $item instanceof self ? $item->toArray() : $item,
-                    $relation
-                );
+                $data[$key] = $relation;
             } else {
                 $data[$key] = $relation;
             }
@@ -105,16 +105,17 @@ abstract class Model
         return $snake . '_id';
     }
 
-    public function hasMany(string $related, ?string $foreignKey = null, ?string $localKey = null): array
+    public function hasMany(string $related, ?string $foreignKey = null, ?string $localKey = null): Collection
     {
         $foreignKey = $foreignKey ?? $this->foreignKeyName(static::class);
         $localKey = $localKey ?? static::$primaryKey;
         $value = $this->attributes[$localKey] ?? null;
         if ($value === null) {
-            return [];
+            return new Collection();
         }
         /** @var class-string<Model> $related */
-        return $related::where([[$foreignKey, '=', $value]]);
+        $results = $related::where([[$foreignKey, '=', $value]]);
+        return new Collection($results);
     }
 
     public function hasOne(string $related, ?string $foreignKey = null, ?string $localKey = null): ?Model
@@ -143,10 +144,10 @@ abstract class Model
         string $localKey = 'id',
         string $relatedKey = 'id',
         bool $withPivot = false
-    ): array {
+    ): Collection {
         $localValue = $this->attributes[$localKey] ?? null;
         if ($localValue === null) {
-            return [];
+            return new Collection();
         }
 
         $db = static::db();
@@ -158,7 +159,7 @@ abstract class Model
             )
             ->fetchAll();
         if (!$pivotRows) {
-            return [];
+            return new Collection();
         }
 
         $relatedIds = array_unique(array_column($pivotRows, $relatedPivotKey));
@@ -188,7 +189,7 @@ abstract class Model
             $results[] = $model;
         }
 
-        return $results;
+        return new Collection($results);
     }
 
     public static function all(): array


### PR DESCRIPTION
## Summary
- add lightweight `Collection` class for holding related models
- return `Collection` instances from `hasMany`/`belongsToMany`
- drop `array_map` conversions in favor of `Collection::toArray()`

## Testing
- `php -l framework/core/Collection.php`
- `php -l framework/core/Model.php`
- `php -l application/Api/Models/ConversationModel.php`
- `php -l application/Api/Models/MessageModel.php`
- `php -l application/Api/Models/UserModel.php`
- `php -l application/Api/Models/DeviceModel.php`
- `php -l application/Api/Models/MessageAttachmentModel.php`
- `php -l application/Api/Models/ConversationParticipantModel.php`
- `php -l application/Api/Device.php`


------
https://chatgpt.com/codex/tasks/task_b_68a52433ab24832a97545460fe96f124