### PR TITLE
Enable array-based belongsToMany options and document pivot joins

### DIFF
--- a/application/Api/Models/ConversationModel.php
+++ b/application/Api/Models/ConversationModel.php
@@ -20,15 +20,14 @@ class ConversationModel extends Model
 
     public function participants(): Collection
     {
-        return $this->belongsToMany(
-            UserModel::class,
-            'conversation_participants',
-            'conversation_id',
-            'user_id',
-            'id',
-            'id',
-            true
-        );
+        // Join table: conversation_participants (conversation_id ↔ user_id)
+        // Pivot fields: role, joined_at, last_read_message_id
+        return $this->belongsToMany(UserModel::class, [
+            'pivotTable'      => 'conversation_participants',
+            'foreignPivotKey' => 'conversation_id',
+            'relatedPivotKey' => 'user_id',
+            'withPivot'       => true,
+        ]);
     }
 
     public function creator(): ?UserModel

--- a/application/Api/Models/UserModel.php
+++ b/application/Api/Models/UserModel.php
@@ -26,12 +26,13 @@ class UserModel extends Model
 
     public function conversations(): Collection
     {
-        return $this->belongsToMany(
-            ConversationModel::class,
-            'conversation_participants',
-            'user_id',
-            'conversation_id'
-        );
+        // Join table: conversation_participants (user_id ↔ conversation_id)
+        // Pivot fields: role, joined_at, last_read_message_id
+        return $this->belongsToMany(ConversationModel::class, [
+            'pivotTable'      => 'conversation_participants',
+            'foreignPivotKey' => 'user_id',
+            'relatedPivotKey' => 'conversation_id',
+        ]);
     }
 
     public function messages(): Collection


### PR DESCRIPTION
## Summary
- allow `belongsToMany` to accept named options array instead of seven positional parameters
- annotate conversation and user models with join table and pivot field details

## Testing
- `php -l framework/core/Model.php`
- `php -l application/Api/Models/ConversationModel.php`
- `php -l application/Api/Models/UserModel.php`


------
https://chatgpt.com/codex/tasks/task_b_68a52cf406bc832aaffdc512a0d69831