### PR TITLE
refactor: switch to cursor pagination

### DIFF
--- a/API_DOCUMENTATION.md
+++ b/API_DOCUMENTATION.md
@@ -156,12 +156,13 @@ Get current user profile.
 
 ### GET /api/conversation
 
-Get user's conversations with pagination.
+Get user's conversations with cursor-based pagination.
 
 **Query Parameters:**
 
-- `page` (int): Page number
-- `per_page` (int): Items per page
+- `limit` (int): Items to return (max: 100, default: 20)
+- `last_id` (int): Last conversation ID received (optional)
+- `last_timestamp` (string): Timestamp of last item for tie-breaking (optional)
 
 **Response:**
 
@@ -183,12 +184,8 @@ Get user's conversations with pagination.
       }
     ],
     "pagination": {
-      "current_page": 1,
-      "per_page": 20,
-      "total": 1,
-      "total_pages": 1,
-      "has_next": false,
-      "has_prev": false
+      "has_more": false,
+      "next": null
     }
   }
 }
@@ -394,8 +391,9 @@ Get messages for a conversation.
 **Query Parameters:**
 
 - `conversation_id` (int): Required
-- `page` (int): Page number
-- `per_page` (int): Items per page (max: 100)
+- `limit` (int): Items to return (max: 100, default: 50)
+- `last_id` (int): Last message ID received (optional)
+- `last_timestamp` (string): Timestamp of last item for tie-breaking (optional)
 - `search` (string): Search within messages
 
 **Response:**
@@ -421,12 +419,11 @@ Get messages for a conversation.
       }
     ],
     "pagination": {
-      "current_page": 1,
-      "per_page": 20,
-      "total": 50,
-      "total_pages": 3,
-      "has_next": true,
-      "has_prev": false
+      "has_more": true,
+      "next": {
+        "last_id": 5,
+        "last_timestamp": "2024-05-01T11:59:00Z"
+      }
     }
   }
 }
@@ -638,8 +635,9 @@ Search messages across all conversations.
 **Query Parameters:**
 
 - `q` (string): Search query
-- `page` (int): Page number
-- `per_page` (int): Items per page
+- `limit` (int): Items to return (max: 100, default: 20)
+- `last_id` (int): Last message ID received (optional)
+- `last_timestamp` (string): Timestamp of last item for tie-breaking (optional)
 
 **Response:**
 
@@ -661,12 +659,11 @@ Search messages across all conversations.
       }
     ],
     "pagination": {
-      "current_page": 1,
-      "per_page": 20,
-      "total": 30,
-      "total_pages": 2,
-      "has_next": true,
-      "has_prev": false
+      "has_more": true,
+      "next": {
+        "last_id": 10,
+        "last_timestamp": "2024-05-01T11:59:00Z"
+      }
     }
   }
 }
@@ -682,8 +679,9 @@ Get user's conversations with pagination.
 
 **Query Parameters:**
 
-- `page` (int): Page number
-- `per_page` (int): Items per page
+- `limit` (int): Items to return (max: 100, default: 20)
+- `last_id` (int): Last conversation ID received (optional)
+- `last_timestamp` (string): Timestamp of last item for tie-breaking (optional)
 
 **Response:**
 
@@ -700,12 +698,11 @@ Get user's conversations with pagination.
       }
     ],
     "pagination": {
-      "current_page": 1,
-      "per_page": 20,
-      "total": 40,
-      "total_pages": 2,
-      "has_next": true,
-      "has_prev": false
+      "has_more": true,
+      "next": {
+        "last_id": 1,
+        "last_timestamp": "2024-05-01T12:34:56Z"
+      }
     }
   }
 }
@@ -748,7 +745,8 @@ Get messages for conversation.
 
 - `conversation_id` (int): Required
 - `limit` (int): Max messages (default: 50, max: 100)
-- `offset` (int): Skip messages (used with limit to calculate page)
+- `last_id` (int): Last message ID received (optional)
+- `last_timestamp` (string): Timestamp of last item for tie-breaking (optional)
 
 **Response:**
 
@@ -766,12 +764,11 @@ Get messages for conversation.
       }
     ],
     "pagination": {
-      "current_page": 1,
-      "per_page": 50,
-      "total": 123,
-      "total_pages": 3,
-      "has_next": true,
-      "has_prev": false
+      "has_more": true,
+      "next": {
+        "last_id": 1,
+        "last_timestamp": "2024-05-01T00:00:00Z"
+      }
     }
   }
 }

--- a/application/Api/ApiController.php
+++ b/application/Api/ApiController.php
@@ -173,4 +173,29 @@ abstract class ApiController extends Controller
             ]
         ], $message);
     }
+
+    /**
+     * Send cursor-based paginated response
+     */
+    protected function respondCursor($data, $limit, $message = 'Success')
+    {
+        $hasMore = count($data) === $limit;
+        $next = null;
+
+        if ($hasMore && !empty($data)) {
+            $last = end($data);
+            $next = [
+                'last_id' => $last['id'] ?? null,
+                'last_timestamp' => $last['created_at'] ?? ($last['last_message_time'] ?? null)
+            ];
+        }
+
+        $this->respondSuccess([
+            'items' => $data,
+            'pagination' => [
+                'has_more' => $hasMore,
+                'next' => $next
+            ]
+        ], $message);
+    }
 }

--- a/application/Api/Conversation.php
+++ b/application/Api/Conversation.php
@@ -18,18 +18,13 @@ class Conversation extends ApiController
         $user = $this->authenticate();
 
         try {
-            $page = (int)($_GET['page'] ?? 1);
-            $perPage = min((int)($_GET['per_page'] ?? 20), 100);
+            $limit = min((int)($_GET['limit'] ?? 20), 100);
+            $lastId = isset($_GET['last_id']) ? (int) $_GET['last_id'] : null;
+            $lastTimestamp = $_GET['last_timestamp'] ?? null;
 
-            $result = ConversationModel::getUserConversationsPaginated($user['user_id'], $page, $perPage);
+            $items = ConversationModel::getUserConversationsPaginated($user['user_id'], $limit, $lastId, $lastTimestamp);
 
-            $this->respondPaginated(
-                $result['items'],
-                $result['total'],
-                $page,
-                $perPage,
-                'Conversations retrieved successfully'
-            );
+            $this->respondCursor($items, $limit, 'Conversations retrieved successfully');
         } catch (\Exception $e) {
             $this->respondError(500, 'Failed to retrieve conversations');
         }


### PR DESCRIPTION
## Summary
- implement cursor-based pagination using `last_id` and optional timestamp
- update conversation and message APIs to use new cursors
- document the new `limit`/`last_id` pagination params

## Testing
- `php -l application/Api/ApiController.php`
- `php -l application/Api/Conversation.php`
- `php -l application/Api/Chat.php`
- `php -l application/Api/Message.php`
- `php -l application/Api/Models/ConversationModel.php`
- `php -l application/Api/Models/MessageModel.php`

------
https://chatgpt.com/codex/tasks/task_b_68a5e881ed88832a842c169405fd7dee