### PR TITLE
Allow searching users by any username words

### DIFF
--- a/application/Api/User.php
+++ b/application/Api/User.php
@@ -23,9 +23,23 @@ class User extends ApiController
         $params = [];
 
         if (!empty($search)) {
-            $whereClause .= " AND (name LIKE ? OR email LIKE ? OR username LIKE ?)";
-            $searchTerm = "%{$search}%";
-            $params = [$searchTerm, $searchTerm, $searchTerm];
+            $words = preg_split('/\s+/', trim($search));
+            $conditions = [];
+
+            foreach ($words as $word) {
+                if ($word === '') {
+                    continue;
+                }
+                $conditions[] = '(name LIKE ? OR email LIKE ? OR username LIKE ?)';
+                $searchTerm = "%{$word}%";
+                $params[] = $searchTerm;
+                $params[] = $searchTerm;
+                $params[] = $searchTerm;
+            }
+
+            if ($conditions) {
+                $whereClause .= ' AND (' . implode(' OR ', $conditions) . ')';
+            }
         }
 
         // Use dataQuery for automatic pagination


### PR DESCRIPTION
## Summary
- support multi-word search in user listing
- allow username search by separate keywords for conversation lookup

## Testing
- `php -l application/Api/User.php`
- `php -l application/Api/Models/UserModel.php`
- `composer validate --no-check-all --no-check-publish`


------
https://chatgpt.com/codex/tasks/task_b_68a5eff3df70832a8b3ea03833017c70