### PR TITLE
refactor: centralize auth handling

### DIFF
--- a/application/Api/ApiController.php
+++ b/application/Api/ApiController.php
@@ -26,6 +26,9 @@ abstract class ApiController extends Controller
             http_response_code(200);
             exit;
         }
+
+        // Populate current user from auth token if available
+        $this->currentUser = CoreAuth::currentUser();
     }
 
     /**
@@ -41,16 +44,6 @@ abstract class ApiController extends Controller
         }
 
         return null;
-    }
-
-    /**
-     * Authenticate the current request
-     */
-    protected function authenticate($required = true)
-    {
-        $user = $required ? CoreAuth::requireAuth() : CoreAuth::currentUser();
-        $this->currentUser = $user;
-        return $user;
     }
 
     /**

--- a/application/Api/Chat.php
+++ b/application/Api/Chat.php
@@ -17,7 +17,7 @@ class Chat extends ApiController
      */
     public function conversations()
     {
-        $user = $this->authenticate();
+        $user = $this->currentUser;
         $limit = min((int)($_GET['limit'] ?? 20), 100);
         $lastId = isset($_GET['last_id']) ? (int) $_GET['last_id'] : null;
         $lastTimestamp = $_GET['last_timestamp'] ?? null;
@@ -40,7 +40,7 @@ class Chat extends ApiController
      */
     public function sendMessage()
     {
-        $user = $this->authenticate();
+        $user = $this->currentUser;
         $data = $this->getJsonInput();
 
         $this->validateRequired($data, ['conversation_id', 'content']);
@@ -104,7 +104,7 @@ class Chat extends ApiController
      */
     public function messages()
     {
-        $user = $this->authenticate();
+        $user = $this->currentUser;
         $conversationId = $_GET['conversation_id'] ?? null;
         $limit = min((int)($_GET['limit'] ?? 50), 100);
         $lastId = isset($_GET['last_id']) ? (int) $_GET['last_id'] : null;
@@ -140,7 +140,7 @@ class Chat extends ApiController
      */
     public function createConversation()
     {
-        $user = $this->authenticate();
+        $user = $this->currentUser;
         $data = $this->getJsonInput();
 
         $this->validateRequired($data, ['type']);
@@ -202,7 +202,7 @@ class Chat extends ApiController
      */
     public function createGroup()
     {
-        $user = $this->authenticate();
+        $user = $this->currentUser;
         $data = $this->getJsonInput();
 
         $this->validateRequired($data, ['name', 'participant_ids']);
@@ -267,7 +267,7 @@ class Chat extends ApiController
      */
     public function findConversation()
     {
-        $user = $this->authenticate();
+        $user = $this->currentUser;
         $username = $_GET['username'] ?? '';
 
         if (empty($username)) {
@@ -296,7 +296,7 @@ class Chat extends ApiController
      */
     public function addReaction()
     {
-        $user = $this->authenticate();
+        $user = $this->currentUser;
         $data = $this->getJsonInput();
 
         $this->validateRequired($data, ['message_id', 'emoji']);
@@ -323,7 +323,7 @@ class Chat extends ApiController
      */
     public function markAsRead()
     {
-        $user = $this->authenticate();
+        $user = $this->currentUser;
         $data = $this->getJsonInput();
 
         $this->validateRequired($data, ['message_id']);
@@ -346,7 +346,7 @@ class Chat extends ApiController
      */
     public function searchMessages()
     {
-        $user = $this->authenticate();
+        $user = $this->currentUser;
         $query = $_GET['q'] ?? '';
         $conversationId = $_GET['conversation_id'] ?? null;
         $limit = min((int)($_GET['limit'] ?? 20), 100);
@@ -379,7 +379,7 @@ class Chat extends ApiController
      */
     public function unreadCount()
     {
-        $user = $this->authenticate();
+        $user = $this->currentUser;
 
         try {
             $totalUnread = ConversationModel::getTotalUnreadCount($user['user_id']);
@@ -401,7 +401,7 @@ class Chat extends ApiController
      */
     public function typingStatus()
     {
-        $user = $this->authenticate();
+        $user = $this->currentUser;
         $conversationId = $_GET['conversation_id'] ?? null;
 
         if (!$conversationId) {
@@ -449,7 +449,7 @@ class Chat extends ApiController
      */
     public function setTyping()
     {
-        $user = $this->authenticate();
+        $user = $this->currentUser;
         $data = $this->getJsonInput();
 
         $this->validateRequired($data, ['conversation_id', 'is_typing']);
@@ -487,7 +487,7 @@ class Chat extends ApiController
      */
     public function onlineUsers()
     {
-        $user = $this->authenticate();
+        $user = $this->currentUser;
         $conversationId = $_GET['conversation_id'] ?? null;
 
         try {

--- a/application/Api/Conversation.php
+++ b/application/Api/Conversation.php
@@ -15,7 +15,7 @@ class Conversation extends ApiController
      */
     public function index()
     {
-        $user = $this->authenticate();
+        $user = $this->currentUser;
 
         try {
             $limit = min((int)($_GET['limit'] ?? 20), 100);
@@ -36,7 +36,7 @@ class Conversation extends ApiController
      */
     public function create()
     {
-        $user = $this->authenticate();
+        $user = $this->currentUser;
         $data = $this->getJsonInput();
 
         $this->validateRequired($data, ['type']);
@@ -118,7 +118,7 @@ class Conversation extends ApiController
             $this->respondError(400, 'Conversation ID is required');
         }
 
-        $user = $this->authenticate();
+        $user = $this->currentUser;
 
         // Check if user is participant
         if (!ConversationParticipantModel::isParticipant($id, $user['user_id'])) {
@@ -147,7 +147,7 @@ class Conversation extends ApiController
             $this->respondError(400, 'Conversation ID is required');
         }
 
-        $user = $this->authenticate();
+        $user = $this->currentUser;
         $data = $this->getJsonInput();
 
         // Check if user is admin
@@ -196,7 +196,7 @@ class Conversation extends ApiController
             $this->respondError(400, 'Conversation ID is required');
         }
 
-        $user = $this->authenticate();
+        $user = $this->currentUser;
 
         // Check if user is admin
         if (!ConversationParticipantModel::isAdmin($id, $user['user_id'])) {
@@ -230,7 +230,7 @@ class Conversation extends ApiController
             $this->respondError(400, 'Conversation ID is required');
         }
 
-        $user = $this->authenticate();
+        $user = $this->currentUser;
 
         // Check if user is participant
         if (!ConversationParticipantModel::isParticipant($id, $user['user_id'])) {
@@ -255,7 +255,7 @@ class Conversation extends ApiController
             $this->respondError(400, 'Conversation ID is required');
         }
 
-        $user = $this->authenticate();
+        $user = $this->currentUser;
         $data = $this->getJsonInput();
 
         $this->validateRequired($data, ['user_ids']);
@@ -301,7 +301,7 @@ class Conversation extends ApiController
             $this->respondError(400, 'Conversation ID is required');
         }
 
-        $user = $this->authenticate();
+        $user = $this->currentUser;
         $data = $this->getJsonInput();
         $this->validateRequired($data, ['user_id']);
 
@@ -334,7 +334,7 @@ class Conversation extends ApiController
             $this->respondError(400, 'Conversation ID is required');
         }
 
-        $user = $this->authenticate();
+        $user = $this->currentUser;
 
         // Check if user is participant
         if (!ConversationParticipantModel::isParticipant($id, $user['user_id'])) {

--- a/application/Api/Device.php
+++ b/application/Api/Device.php
@@ -13,7 +13,7 @@ class Device extends ApiController
      */
     public function register()
     {
-        $user = $this->authenticate();
+        $user = $this->currentUser;
         $data = $this->getJsonInput();
 
         $this->validateRequired($data, ['device_id', 'platform']);
@@ -43,7 +43,7 @@ class Device extends ApiController
      */
     public function index()
     {
-        $user = $this->authenticate();
+        $user = $this->currentUser;
 
         try {
             $userModel = UserModel::find($user['user_id']);
@@ -64,7 +64,7 @@ class Device extends ApiController
             $this->respondError(400, 'Device ID is required');
         }
 
-        $user = $this->authenticate();
+        $user = $this->currentUser;
         $data = $this->getJsonInput();
 
         // Check if device belongs to user
@@ -118,7 +118,7 @@ class Device extends ApiController
             $this->respondError(400, 'Device ID is required');
         }
 
-        $user = $this->authenticate();
+        $user = $this->currentUser;
 
         try {
             $result = DeviceModel::removeDevice($user['user_id'], $deviceId);
@@ -142,7 +142,7 @@ class Device extends ApiController
             $this->respondError(400, 'Device ID is required');
         }
 
-        $user = $this->authenticate();
+        $user = $this->currentUser;
 
         try {
             $result = DeviceModel::updateLastActive($user['user_id'], $deviceId);
@@ -164,7 +164,7 @@ class Device extends ApiController
      */
     public function testNotification()
     {
-        $user = $this->authenticate();
+        $user = $this->currentUser;
         $data = $this->getJsonInput();
 
         $deviceId = $data['device_id'] ?? null;

--- a/application/Api/Message.php
+++ b/application/Api/Message.php
@@ -15,7 +15,7 @@ class Message extends ApiController
      */
     public function index()
     {
-        $user = $this->authenticate();
+        $user = $this->currentUser;
         $conversationId = $_GET['conversation_id'] ?? null;
         $search = $_GET['search'] ?? '';
         $limit = min((int)($_GET['limit'] ?? 50), 100);
@@ -45,7 +45,7 @@ class Message extends ApiController
      */
     public function create()
     {
-        $user = $this->authenticate();
+        $user = $this->currentUser;
         $data = $this->getJsonInput();
 
         $this->validateRequired($data, ['conversation_id', 'content']);
@@ -110,7 +110,7 @@ class Message extends ApiController
             $this->respondError(400, 'Message ID is required');
         }
 
-        $user = $this->authenticate();
+        $user = $this->currentUser;
 
         try {
             $message = MessageModel::getMessageWithDetails($id);
@@ -139,7 +139,7 @@ class Message extends ApiController
             $this->respondError(400, 'Message ID is required');
         }
 
-        $user = $this->authenticate();
+        $user = $this->currentUser;
         $data = $this->getJsonInput();
 
         $this->validateRequired($data, ['content']);
@@ -183,7 +183,7 @@ class Message extends ApiController
             $this->respondError(400, 'Message ID is required');
         }
 
-        $user = $this->authenticate();
+        $user = $this->currentUser;
 
         try {
             // Check if message exists and user is the sender
@@ -221,7 +221,7 @@ class Message extends ApiController
             $this->respondError(400, 'Message ID is required');
         }
 
-        $user = $this->authenticate();
+        $user = $this->currentUser;
         $data = $this->getJsonInput();
 
         $this->validateRequired($data, ['emoji']);
@@ -263,7 +263,7 @@ class Message extends ApiController
             $this->respondError(400, 'Message ID is required');
         }
 
-        $user = $this->authenticate();
+        $user = $this->currentUser;
 
         try {
             // Check if message exists and user has access
@@ -293,7 +293,7 @@ class Message extends ApiController
      */
     public function upload()
     {
-        $user = $this->authenticate();
+        $user = $this->currentUser;
 
         if (!isset($_FILES['file']) || $_FILES['file']['error'] !== UPLOAD_ERR_OK) {
             $this->respondError(400, 'No valid file uploaded');
@@ -378,7 +378,7 @@ class Message extends ApiController
      */
     public function search()
     {
-        $user = $this->authenticate();
+        $user = $this->currentUser;
         $query = $_GET['q'] ?? '';
         $limit = min((int)($_GET['limit'] ?? 50), 100);
         $lastId = isset($_GET['last_id']) ? (int) $_GET['last_id'] : null;

--- a/application/Api/Status.php
+++ b/application/Api/Status.php
@@ -49,7 +49,7 @@ class Status extends ApiController
      */
     public function auth()
     {
-        $user = $this->authenticate();
+        $user = $this->currentUser;
 
         $this->respondSuccess([
             'authenticated' => true,

--- a/application/Api/User.php
+++ b/application/Api/User.php
@@ -16,8 +16,6 @@ class User extends ApiController
     {
         $search = $_GET['search'] ?? '';
 
-        $this->authenticate();
-
         // Build search conditions
         $whereClause = "WHERE deleted_at IS NULL";
         $params = [];
@@ -53,8 +51,6 @@ class User extends ApiController
             $this->respondError(400, 'User ID is required');
         }
 
-        $this->authenticate();
-
         $user = UserModel::findById($id);
 
         if (!$user) {
@@ -72,8 +68,6 @@ class User extends ApiController
         if (!$username) {
             $this->respondError(400, 'Username is required');
         }
-
-        $this->authenticate();
 
         $user = UserModel::getUserByUsername($username);
 
@@ -93,7 +87,7 @@ class User extends ApiController
             $this->respondError(400, 'User ID is required');
         }
 
-        $currentUser = $this->authenticate();
+        $currentUser = $this->currentUser;
         $data = $this->getJsonInput();
 
         // Check if user can update this profile (own profile or admin)
@@ -147,7 +141,7 @@ class User extends ApiController
             $this->respondError(400, 'User ID is required');
         }
 
-        $currentUser = $this->authenticate();
+        $currentUser = $this->currentUser;
 
         // Check if user can delete this profile (own profile or admin)
         if ($currentUser['user_id'] != $id) {
@@ -185,7 +179,7 @@ class User extends ApiController
             $this->respondError(400, 'User ID is required');
         }
 
-        $currentUser = $this->authenticate();
+        $currentUser = $this->currentUser;
 
         // Check if user can update this profile
         if ($currentUser['user_id'] != $id) {
@@ -263,8 +257,6 @@ class User extends ApiController
             $this->respondError(400, 'Search query is required');
         }
 
-        $this->authenticate();
-
         $users = UserModel::searchUsers($query, $limit);
 
         $this->respondSuccess($users, 'Users found successfully');
@@ -275,7 +267,7 @@ class User extends ApiController
      */
     public function me()
     {
-        $user = $this->authenticate();
+        $user = $this->currentUser;
 
         $userInfo = UserModel::findById($user['user_id']);
 
@@ -401,7 +393,7 @@ class User extends ApiController
      */
     public function logout()
     {
-        $user = $this->authenticate();
+        $user = $this->currentUser;
         $token = $this->getAuthToken();
 
         if ($token) {
@@ -416,7 +408,7 @@ class User extends ApiController
      */
     public function refresh()
     {
-        $user = $this->authenticate();
+        $user = $this->currentUser;
 
         // Create new token
         $newToken = AuthTokenModel::createToken(

--- a/framework/core/Auth.php
+++ b/framework/core/Auth.php
@@ -22,6 +22,12 @@ class Auth
      */
     public static function checkPermission($section, $controller, $action)
     {
+        // Skip auth for login and register endpoints
+        $section = trim($section, '/\\');
+        if ($section === 'Api' && $controller === 'User' && in_array(strtolower($action), ['login', 'register'])) {
+            return true;
+        }
+
         // Ensure user is authenticated globally
         self::requireAuth();
 


### PR DESCRIPTION
## Summary
- rely on core Auth::checkPermission to handle authentication and skip login/register
- drop per-controller authenticate calls and use ApiController currentUser property
- use framework auth properties in API controllers

## Testing
- `php -l framework/core/Auth.php`
- `php -l application/Api/ApiController.php`
- `php -l application/Api/Conversation.php`
- `php -l application/Api/Message.php`
- `php -l application/Api/User.php`
- `php -l application/Api/Chat.php`
- `php -l application/Api/Device.php`
- `php -l application/Api/Status.php`


------
https://chatgpt.com/codex/tasks/task_b_68a5f04b8428832ab3cd72598a4565f8