### PR TITLE
feat: add group management endpoints

### DIFF
--- a/API_DOCUMENTATION.md
+++ b/API_DOCUMENTATION.md
@@ -787,6 +787,18 @@ Create new conversation.
 
 Create a new group conversation.
 
+### POST /api/chat/add-participants
+
+Add users to an existing group conversation.
+
+### POST /api/chat/remove-participant
+
+Remove a user from a group conversation.
+
+### POST /api/chat/rename-group
+
+Rename a group conversation.
+
 ### GET /api/chat/find-conversation
 
 Find existing direct conversation by username.


### PR DESCRIPTION
## Summary
- add API endpoints to add/remove participants and rename group conversations
- document group management endpoints in API docs

## Testing
- `php -l application/Api/Chat.php`


------
https://chatgpt.com/codex/tasks/task_b_68a5f4e4e8b0832a9885210550f78cc0